### PR TITLE
Update default GHCi prompt

### DIFF
--- a/docs/starting-out.html
+++ b/docs/starting-out.html
@@ -38,10 +38,11 @@
 Alright, let's get started! If you're the sort of horrible person who doesn't read introductions to things and you skipped it, you might want to read the last section in the introduction anyway because it explains what you need to follow this tutorial and how we're going to load functions. The first thing we're going to do is run ghc's interactive mode and call some function to get a very basic feel for Haskell. Open your terminal and type in <span class="fixed">ghci</span>. You will be greeted with something like this.
 </p>
 <pre name="code" class="haskell: ghci">
-GHCi, version 8.10.7: https://www.haskell.org/ghc/  :? for help
-Prelude&gt;</pre>
+GHCi, version 9.2.4: https://www.haskell.org/ghc/  :? for help
+ghci&gt;
+</pre>
 <p>
-Congratulations, you're in GHCI! The prompt here is <span class="fixed">Prelude&gt;</span> but because it can get longer when you load stuff into the session, we're going to use <span class="fixed">ghci&gt;</span>. If you want to have the same prompt, just type in <span class="fixed">:set prompt "ghci&gt; "</span>.
+Congratulations, you're in GHCI!
 </p>
 <p>
 Here's some simple arithmetic.


### PR DESCRIPTION
Now that GHC 9.2.4 is the compiler recommended by GHCup the time has come to update the GHCi prompt in the book, as noted in _https://github.com/learnyouahaskell/learnyouahaskell.github.io/issues/24#issuecomment-1174916508_.