### PR TITLE
Typo and clarity in for-a-few-monads-more

### DIFF
--- a/docs/for-a-few-monads-more.html
+++ b/docs/for-a-few-monads-more.html
@@ -1071,7 +1071,7 @@ returns a monadic value, which is a function in our case, so we apply it to
 </p>
 
 <p>
-If don't get how <span class="fixed">&gt;&gt;=</span> works at this point, don't
+If you don't understand how <span class="fixed">&gt;&gt;=</span> works at this point, don't
 worry, because with examples we'll see how this is a really simple monad. Here's
 a <span class="fixed">do</span> expression that utilizes this monad:
 </p>

--- a/markdown/source_md/for-a-few-monads-more.md
+++ b/markdown/source_md/for-a-few-monads-more.md
@@ -676,7 +676,7 @@ The same thing happens here.
 To get the result from a function, we have to apply it to something, which is why we do `(h w)` here to get the result from the function and then we apply `f` to that.
 `f` returns a monadic value, which is a function in our case, so we apply it to `w` as well.
 
-If don't get how `>>=` works at this point, don't worry, because with examples we'll see how this is a really simple monad.
+If you don't understand how `>>=` works at this point, don't worry, because with examples we'll see how this is a really simple monad.
 Here's a `do` expression that utilizes this monad:
 
 ```{.haskell:hs}


### PR DESCRIPTION
Reported in #6

`If don't get how >>= works at this point` -> `If you don't understand how >>= works at this point`
