### PR TITLE
Update markdown to add corrections from recent typo PRs

### DIFF
--- a/markdown/generated_html/a-fistful-of-monads.html
+++ b/markdown/generated_html/a-fistful-of-monads.html
@@ -272,7 +272,7 @@ are just beefed up applicative functors? Shouldn’t there be a class
 constraint in there along the lines of
 <code>class (Applicative m) = &gt; Monad m where</code> so that a type
 has to be an applicative functor first before it can be made a monad?
-Well, there should, but when Haskell was made, it hadn’t occured to
+Well, there should, but when Haskell was made, it hadn’t occurred to
 people that applicative functors are a good fit for Haskell so they
 weren’t in there. But rest assured, every monad is an applicative
 functor, even if the <code>Monad</code> class declaration doesn’t say

--- a/markdown/generated_html/for-a-few-monads-more.html
+++ b/markdown/generated_html/for-a-few-monads-more.html
@@ -680,9 +680,10 @@ we do <code>(h w)</code> here to get the result from the function and
 then we apply <code>f</code> to that. <code>f</code> returns a monadic
 value, which is a function in our case, so we apply it to <code>w</code>
 as well.</p>
-<p>If don’t get how <code>&gt;&gt;=</code> works at this point, don’t
-worry, because with examples we’ll see how this is a really simple
-monad. Here’s a <code>do</code> expression that utilizes this monad:</p>
+<p>If you don’t understand how <code>&gt;&gt;=</code> works at this
+point, don’t worry, because with examples we’ll see how this is a really
+simple monad. Here’s a <code>do</code> expression that utilizes this
+monad:</p>
 <pre class="haskell:hs"><code>import Control.Monad.Instances
 
 addStuff :: Int -&gt; Int

--- a/markdown/generated_html/for-a-few-monads-more.html
+++ b/markdown/generated_html/for-a-few-monads-more.html
@@ -74,8 +74,8 @@ a big gang or not. That’s a very simple function:</p>
 isBigGang x = x &gt; 9</code></pre>
 <p>Now, what if instead of just giving us a <code>True</code> or
 <code>False</code> value, we want it to also return a log string that
-says what it did? Well, we just make that string and return it along
-side our <code>Bool</code>:</p>
+says what it did? Well, we just make that string and return it alongside
+our <code>Bool</code>:</p>
 <pre class="haskell:hs"><code>isBigGang :: Int -&gt; (Bool, String)
 isBigGang x = (x &gt; 9, &quot;Compared gang size to 9.&quot;)</code></pre>
 <p>So now instead of just returning a <code>Bool</code>, we return a
@@ -376,8 +376,8 @@ instance, if we want to know what the greatest common divisor of 8 and 3
 is, we just follow the algorithm outlined. Because 3 isn’t 0, we have to
 find the greatest common divisor of 3 and 2 (if we divide 8 by 3, the
 remainder is 2). Next, we find the greatest common divisor of 3 and 2. 2
-still isn’t 0, so now we have have 2 and 1. The second number isn’t 0,
-so we run the algorithm again for 1 and 0, as dividing 2 by 1 gives us a
+still isn’t 0, so now we have 2 and 1. The second number isn’t 0, so we
+run the algorithm again for 1 and 0, as dividing 2 by 1 gives us a
 remainder of 0. And finally, because the second number is now 0, the
 final result is 1. Let’s see if our code agrees:</p>
 <pre class="haskell:hs"><code>ghci&gt; gcd&#39; 8 3
@@ -795,7 +795,7 @@ one on top of another and you can either push stuff on top of that stack
 or you can take stuff off the top of the stack. When you’re putting an
 item on top of the stack we say that you’re pushing it to the stack and
 when you’re taking stuff off the top we say that you’re popping it. If
-you want to something that’s at the bottom of the stack, you have to pop
+you want something that’s at the bottom of the stack, you have to pop
 everything that’s above it.</p>
 <p>We’ll use a list to represent our stack and the head of the list will
 be the top of the stack. To help us with our task, we’ll make two
@@ -1031,7 +1031,7 @@ threeCoins = do
     b &lt;- randomSt
     c &lt;- randomSt
     return (a,b,c)</code></pre>
-<p><code>threeCoins</code> is now a stateful computations and after
+<p><code>threeCoins</code> is now a stateful computation and after
 taking an initial random generator, it passes it to the first
 <code>randomSt</code>, which produces a number and a new generator,
 which gets passed to the next one and so on. We use
@@ -1771,7 +1771,7 @@ points and use <code>Rational</code> for our probabilities:</p>
 while <code>5</code> and <code>9</code> will happen one time out of
 four. Pretty neat.</p>
 <p>We took lists and we added some extra context to them, so this
-represents values withs contexts too. Before we go any further, let’s
+represents values with contexts too. Before we go any further, let’s
 wrap this into a <code>newtype</code> because something tells me we’ll
 be making some instances.</p>
 <pre class="haskell:hs"><code>import Data.Ratio

--- a/markdown/generated_html/functionally-solving-problems.html
+++ b/markdown/generated_html/functionally-solving-problems.html
@@ -38,8 +38,8 @@ how to think functionally to solve them as elegantly as possible. We
 probably won’t be introducing any new concepts, we’ll just be flexing
 our newly acquired Haskell muscles and practicing our coding skills.
 Each section will present a different problem. First we’ll describe the
-problem, then we’ll try and find out what the best (or least worst) way
-of solving it is.</p>
+problem, then we’ll try and find out what the best (or least bad) way of
+solving it is.</p>
 <h2 id="reverse-polish-notation-calculator">Reverse Polish notation
 calculator</h2>
 <p>Usually when we write mathematical expressions in school, we write
@@ -225,7 +225,7 @@ ghci&gt; solveRPN &quot;90 3 -&quot;
 easily modified to support various other operators. They don’t even have
 to be binary operators. For instance, we can make an operator
 <code>"log"</code> that just pops one number off the stack and pushes
-back its logarithm. We can also make a ternary operators that pop three
+back its logarithm. We can also make ternary operators that pop three
 numbers off the stack and push back a result or operators like
 <code>"sum"</code> which pop off all the numbers and push back their
 sum.</p>
@@ -265,15 +265,16 @@ because <code>read</code> knows how to read them.</p>
 <p>I think that making a function that can calculate arbitrary floating
 point RPN expressions and has the option to be easily extended in 10
 lines is pretty awesome.</p>
-<p>One thing to note about this function is that it’s not really fault
-tolerant. When given input that doesn’t make sense, it will just crash
-everything. We’ll make a fault tolerant version of this with a type
-declaration of <code>solveRPN :: String -&gt; Maybe Float</code> once we
-get to know monads (they’re not scary, trust me!). We could make one
-right now, but it would be a bit tedious because it would involve a lot
-of checking for <code>Nothing</code> on every step. If you’re feeling up
-to the challenge though, you can go ahead and try it! Hint: you can use
-<code>reads</code> to see if a read was successful or not.</p>
+<p>One thing to note about this function is that it’s not really
+fault-tolerant. When given input that doesn’t make sense, it will just
+crash everything. We’ll make a fault tolerant version of this with a
+type declaration of <code>solveRPN :: String -&gt; Maybe Float</code>
+once we get to know monads (they’re not scary, trust me!). We could make
+one right now, but it would be a bit tedious because it would involve a
+lot of checking for <code>Nothing</code> on every step. If you’re
+feeling up to the challenge though, you can go ahead and try it! Hint:
+you can use <code>reads</code> to see if a read was successful or
+not.</p>
 <h2 id="heathrow-to-london">Heathrow to London</h2>
 <p>Our next problem is this: your plane has just landed in England and
 you rent a car. You have a meeting really soon and you have to get from

--- a/markdown/generated_html/functors-applicative-functors-and-monoids.html
+++ b/markdown/generated_html/functors-applicative-functors-and-monoids.html
@@ -206,7 +206,7 @@ what the heck does <code>(-&gt;) r</code> mean? The function type
 <code>r -&gt; a</code> can be rewritten as <code>(-&gt;) r a</code>,
 much like we can write <code>2 + 3</code> as <code>(+) 2 3</code>. When
 we look at it as <code>(-&gt;) r a</code>, we can see
-<code>(-&gt;)</code> in a slighty different light, because we see that
+<code>(-&gt;)</code> in a slightly different light, because we see that
 it’s just a type constructor that takes two type parameters, just like
 <code>Either</code>. But remember, we said that a type constructor has
 to take exactly one type parameter so that it can be made an instance of
@@ -493,7 +493,7 @@ CJust 100 [1,2,3]</code></pre>
 <p>If we use the <code>CNothing</code> constructor, there are no fields,
 and if we use the <code>CJust</code> constructor, the first field is an
 integer and the second field can be any type. Let’s make this an
-instance of <code>Functor</code> so that everytime we use
+instance of <code>Functor</code> so that every time we use
 <code>fmap</code>, the function gets applied to the second field,
 whereas the first field gets increased by 1.</p>
 <pre class="haskell:hs"><code>instance Functor CMaybe where
@@ -844,7 +844,7 @@ might be thinking that applicative functors are all about
 <code>Maybe</code>. There are loads of other instances of
 <code>Applicative</code>, so let’s go and meet them!</p>
 <p>Lists (actually the list type constructor, <code>[]</code>) are
-applicative functors. What a suprise! Here’s how <code>[]</code> is an
+applicative functors. What a surprise! Here’s how <code>[]</code> is an
 instance of <code>Applicative</code>:</p>
 <pre class="haskell:hs"><code>instance Applicative [] where
     pure x = [x]
@@ -1557,14 +1557,14 @@ ghci&gt; getPair $ fmap reverse (Pair (&quot;london calling&quot;, 3))
 <em>data</em>. The only thing that can be done with <em>newtype</em> is
 turning an existing type into a new type, so internally, Haskell can
 represent the values of types defined with <em>newtype</em> just like
-the original ones, only it has to keep in mind that the their types are
-now distinct. This fact means that not only is <em>newtype</em> faster,
-it’s also lazier. Let’s take a look at what this means.</p>
+the original ones, only it has to keep in mind that the types are now
+distinct. This fact means that not only is <em>newtype</em> faster, it’s
+also lazier. Let’s take a look at what this means.</p>
 <p>Like we’ve said before, Haskell is lazy by default, which means that
 only when we try to actually print the results of our functions will any
-computation take place. Furthemore, only those computations that are
+computation take place. Furthermore, only those computations that are
 necessary for our function to tell us the result will get carried out.
-The <code>undefined</code> value in Haskell represents an erronous
+The <code>undefined</code> value in Haskell represents an erroneous
 computation. If we try to evaluate it (that is, force Haskell to
 actually compute it) by printing it to the terminal, Haskell will throw
 a hissy fit (technically referred to as an exception):</p>
@@ -2227,7 +2227,7 @@ structure. Trees especially lend themselves well to folding.</p>
 folds, the <code class="label class">Foldable</code> type class was
 introduced. Much like <code>Functor</code> is for things that can be
 mapped over, <code>Foldable</code> is for things that can be folded up!
-It can be found in <code>Data.Foldable</code> and because it export
+It can be found in <code>Data.Foldable</code> and because it exports
 functions whose names clash with the ones from the <code>Prelude</code>,
 it’s best imported qualified (and served with basil):</p>
 <pre class="haskell:hs"><code>import qualified Foldable as F</code></pre>
@@ -2307,23 +2307,23 @@ element of our tree and returns a monoid value, how do we reduce our
 whole tree down to one single monoid value? When we were doing
 <code>fmap</code> over our tree, we applied the function that we were
 mapping to a node and then we recursively mapped the function over the
-left sub-tree as well as the right one. Here, we’re tasked with not only
+left subtree as well as the right one. Here, we’re tasked with not only
 mapping a function, but with also joining up the results into a single
 monoid value by using <code>mappend</code>. First we consider the case
 of the empty tree — a sad and lonely tree that has no values or
-sub-trees. It doesn’t hold any value that we can give to our
+subtrees. It doesn’t hold any value that we can give to our
 monoid-making function, so we just say that if our tree is empty, the
 monoid value it becomes is <code>mempty</code>.</p>
 <p>The case of a non-empty node is a bit more interesting. It contains
-two sub-trees as well as a value. In this case, we recursively
+two subtrees as well as a value. In this case, we recursively
 <code>foldMap</code> the same function <code>f</code> over the left and
-the right sub-trees. Remember, our <code>foldMap</code> results in a
+the right subtrees. Remember, our <code>foldMap</code> results in a
 single monoid value. We also apply our function <code>f</code> to the
 value in the node. Now we have three monoid values (two from our
-sub-trees and one from applying <code>f</code> to the value in the node)
+subtrees and one from applying <code>f</code> to the value in the node)
 and we just have to bang them together into a single value. For this
-purpose we use <code>mappend</code>, and naturally the left sub-tree
-comes first, then the node value and then the right sub-tree.</p>
+purpose we use <code>mappend</code>, and naturally the left subtree
+comes first, then the node value and then the right subtree.</p>
 <p>Notice that we didn’t have to provide the function that takes a value
 and returns a monoid value. We receive that function as a parameter to
 <code>foldMap</code> and all we have to decide is where to apply that

--- a/markdown/generated_html/higher-order-functions.html
+++ b/markdown/generated_html/higher-order-functions.html
@@ -113,7 +113,7 @@ could do something like this:</p>
 <pre class="haskell:hs"><code>compareWithHundred :: (Num a, Ord a) =&gt; a -&gt; Ordering
 compareWithHundred x = compare 100 x</code></pre>
 <p>If we call it with <code>99</code>, it returns a <code>GT</code>.
-Simple stuff. Notice that the <code>x</code> is on the right hand side
+Simple stuff. Notice that the <code>x</code> is on the right-hand side
 on both sides of the equation. Now let’s think about what
 <code>compare 100</code> returns. It returns a function that takes a
 number and compares it with <code>100</code>. Wow! Isn’t that the
@@ -354,13 +354,14 @@ ghci&gt; filter (`elem` [&#39;a&#39;..&#39;z&#39;]) &quot;u LaUgH aT mE BeCaUsE 
 &quot;uagameasadifeent&quot;
 ghci&gt; filter (`elem` [&#39;A&#39;..&#39;Z&#39;]) &quot;i Laugh At you Because u R All The Same&quot;
 &quot;LABRATS&quot;</code></pre>
-<p>All of this could also be achived with list comprehensions by the use
-of predicates. There’s no set rule for when to use <code>map</code> and
-<code>filter</code> versus using list comprehension, you just have to
-decide what’s more readable depending on the code and the context. The
-<code>filter</code> equivalent of applying several predicates in a list
-comprehension is either filtering something several times or joining the
-predicates with the logical <code>&amp;&amp;</code> function.</p>
+<p>All of this could also be achieved with list comprehensions by the
+use of predicates. There’s no set rule for when to use <code>map</code>
+and <code>filter</code> versus using list comprehension, you just have
+to decide what’s more readable depending on the code and the context.
+The <code>filter</code> equivalent of applying several predicates in a
+list comprehension is either filtering something several times or
+joining the predicates with the logical <code>&amp;&amp;</code>
+function.</p>
 <p>Remember our quicksort function from the <a
 href="recursion.html">previous chapter</a>? We used list comprehensions
 to filter out the list elements that are smaller than (or equal to) and
@@ -671,7 +672,7 @@ map&#39; f xs = foldr (\x acc -&gt; f x : acc) [] xs</code></pre>
 <p>If we’re mapping <code>(+3)</code> to <code>[1,2,3]</code>, we
 approach the list from the right side. We take the last element, which
 is <code>3</code> and apply the function to it, which ends up being
-<code>6</code>. Then, we prepend it to the accumulator, which is was
+<code>6</code>. Then, we prepend it to the accumulator, which is
 <code>[]</code>. <code>6:[]</code> is <code>[6]</code> and that’s now
 the accumulator. We apply <code>(+3)</code> to <code>2</code>, that’s
 <code>5</code> and we prepend (<code>:</code>) it to the accumulator, so
@@ -801,8 +802,8 @@ ghci&gt; sum (map sqrt [1..130])
 <p>We use <code>takeWhile</code> here instead of <code>filter</code>
 because <code>filter</code> doesn’t work on infinite lists. Even though
 we know the list is ascending, <code>filter</code> doesn’t, so we use
-<code>takeWhile</code> to cut the scanlist off at the first occurence of
-a sum greater than 1000.</p>
+<code>takeWhile</code> to cut the scanlist off at the first occurrence
+of a sum greater than 1000.</p>
 <h2 id="function-application">Function application with $</h2>
 <p>Alright, next up, we’ll take a look at the <code>$</code> function,
 also called <em>function application</em>. First of all, let’s check out
@@ -827,10 +828,10 @@ low precedence, we can rewrite that expression as
 keystrokes! When a <code>$</code> is encountered, the expression on its
 right is applied as the parameter to the function on its left. How about
 <code>sqrt 3 + 4 + 9</code>? This adds together 9, 4 and the square root
-of 3. If we want get the square root of <em>3 + 4 + 9</em>, we’d have to
-write <code>sqrt (3 + 4 + 9)</code> or if we use <code>$</code> we can
-write it as <code>sqrt $ 3 + 4 + 9</code> because <code>$</code> has the
-lowest precedence of any operator. That’s why you can imagine a
+of 3. If we want to get the square root of <em>3 + 4 + 9</em>, we’d have
+to write <code>sqrt (3 + 4 + 9)</code> or if we use <code>$</code> we
+can write it as <code>sqrt $ 3 + 4 + 9</code> because <code>$</code> has
+the lowest precedence of any operator. That’s why you can imagine a
 <code>$</code> being sort of the equivalent of writing an opening
 parentheses and then writing a closing one on the far right side of the
 expression.</p>
@@ -921,8 +922,8 @@ currying, we can omit the <code>xs</code> on both sides, because calling
 the function as <code>sum' = foldl (+) 0</code> is called writing it in
 point free style. How would we write this in point free style?</p>
 <pre class="haskell:hs"><code>fn x = ceiling (negate (tan (cos (max 50 x))))</code></pre>
-<p>We can’t just get rid of the <code>x</code> on both right right
-sides. The <code>x</code> in the function body has parentheses after it.
+<p>We can’t just get rid of the <code>x</code> on both right sides. The
+<code>x</code> in the function body has parentheses after it.
 <code>cos (max 50)</code> wouldn’t make sense. You can’t get the cosine
 of a function. What we can do is express <code>fn</code> as a
 composition of functions.</p>
@@ -935,7 +936,7 @@ composition as glue to form more complex functions. However, many times,
 writing a function in point free style can be less readable if a
 function is too complex. That’s why making long chains of function
 composition is discouraged, although I plead guilty of sometimes being
-too composition-happy. The prefered style is to use <em>let</em>
+too composition-happy. The preferred style is to use <em>let</em>
 bindings to give labels to intermediary results or split the problem
 into sub-problems and then put it together so that the function makes
 sense to someone reading it instead of just making a huge composition

--- a/markdown/generated_html/input-and-output.html
+++ b/markdown/generated_html/input-and-output.html
@@ -79,7 +79,7 @@ schtick.</p>
 <div class="hintbox">
 <p><strong>Hey!</strong> For the purposes of this chapter, I’m going to
 assume you’re using a unix-y environment for learning Haskell. If you’re
-in Windows, I’d suggest you download <a
+on Windows, I’d suggest you download <a
 href="https://www.cygwin.com/">Cygwin</a>, which is a Linux-like
 environment for Windows, A.K.A. just what you need.</p>
 </div>
@@ -928,8 +928,8 @@ to and reading from files is very much like writing to the standard
 output and reading from the standard input.</p>
 <p>We’ll start off with a really simple program that opens a file called
 <em>girlfriend.txt</em>, which contains a verse from Avril Lavigne’s
-#1 hit <em>Girlfriend</em>, and just prints out out to the terminal.
-Here’s <em>girlfriend.txt</em>:</p>
+#1 hit <em>Girlfriend</em>, and just prints out to the terminal. Here’s
+<em>girlfriend.txt</em>:</p>
 <pre class="plain"><code>Hey! Hey! You! You!
 I don&#39;t like your girlfriend!
 No way! No way!
@@ -1275,8 +1275,8 @@ number, not a string, we run <code>read</code> on that to get
 <code>1</code> and bind that to <code>number</code>.</p>
 <p>Remember the <code>delete</code> and <code>!!</code> functions from
 <code>Data.List</code>. <code>!!</code> returns an element from a list
-with some index and <code>delete</code> deletes the first occurence of
-an element in a list and returns a new list without that occurence.
+with some index and <code>delete</code> deletes the first occurrence of
+an element in a list and returns a new list without that occurrence.
 <code>(todoTasks !! number)</code> (number is now <code>1</code>)
 returns <code>"Dust the dog"</code>. We bind <code>todoTasks</code>
 without the first occurence of <code>"Dust the dog"</code> to
@@ -1583,8 +1583,8 @@ that task to the top of the to-do list.</p>
 <p>You could make this program fail a bit more gracefully in case of bad
 input (for example, if someone runs <code>todo UP YOURS HAHAHAHA</code>)
 by making an I/O action that just reports there has been an error (say,
-<code>errorExit :: IO ()</code>) and then check for possible erronous
-input and if there is erronous input, perform the error reporting I/O
+<code>errorExit :: IO ()</code>) and then check for possible erroneous
+input and if there is erroneous input, perform the error reporting I/O
 action. Another way is to use exceptions, which we will meet soon.</p>
 <h2 id="randomness">Randomness</h2>
 <p><img src="assets/images/input-and-output/random.png" class="right"
@@ -1756,9 +1756,9 @@ new generator. That will be the head. Then we say that the tail will be
 the head and the rest of the list joined and the final generator that we
 got from getting the <em>n - 1</em> random numbers.</p>
 <p>What if we want a random value in some sort of range? All the random
-integers so far were outrageously big or small. What if we want to to
-throw a die? Well, we use <code class="label function">randomR</code>
-for that purpose. It has a type of
+integers so far were outrageously big or small. What if we want to throw
+a die? Well, we use <code class="label function">randomR</code> for that
+purpose. It has a type of
 <code>randomR :: (RandomGen g, Random a) :: (a, a) -&gt; g -&gt; (a, g)</code>,
 meaning that it’s kind of like <code>random</code>, only it takes as its
 first parameter a pair of values that set the lower and upper bounds and
@@ -1781,7 +1781,7 @@ programs, they will always return the same random numbers, which is no
 good for us. That’s why <code>System.Random</code> offers the <code
 class="label function">getStdGen</code> I/O action, which has a type of
 <code>IO StdGen</code>. When your program starts, it asks the system for
-a good random number generator and stores that in a so called global
+a good random number generator and stores that in a so-called global
 generator. <code>getStdGen</code> fetches you that global random
 generator when you bind it to something.</p>
 <p>Here’s a simple program that generates a random string.</p>
@@ -1882,7 +1882,7 @@ number, so <code>number</code> is now <code>7</code>.</p>
 <p><strong>Excuse me!</strong> If the user gives us some input here that
 <code>read</code> can’t read (like <code>"haha"</code>), our program
 will crash with an ugly error message. If you don’t want your program to
-crash on erronous input, use <code class="label function">reads</code>,
+crash on erroneous input, use <code class="label function">reads</code>,
 which returns an empty list when it fails to read a string. When it
 succeeds, it returns a singleton list with a tuple that has our desired
 value as one component and a string with what it didn’t consume as the
@@ -1950,7 +1950,7 @@ only be accessed when the need arises.</p>
 slow. As you know, <code>String</code> is a type synonym for
 <code>[Char]</code>. <code>Char</code>s don’t have a fixed size, because
 it takes several bytes to represent a character from, say, Unicode.
-Furthemore, lists are really lazy. If you have a list like
+Furthermore, lists are really lazy. If you have a list like
 <code>[1,2,3,4]</code>, it will be evaluated only when completely
 necessary. So the whole list is sort of a promise of a list. Remember
 that <code>[1,2,3,4]</code> is syntactic sugar for
@@ -2023,7 +2023,7 @@ Chunk &quot;can&quot; Empty
 ghci&gt; B.pack [98..120]
 Chunk &quot;bcdefghijklmnopqrstuvwx&quot; Empty</code></pre>
 <p>As you can see, you usually don’t have to worry about the
-<code>Word8</code> too much, because the type system can makes the
+<code>Word8</code> too much, because the type system can make the
 numbers choose that type. If you try to use a big number, like
 <code>336</code> as a <code>Word8</code>, it will just wrap around to
 <code>80</code>.</p>
@@ -2141,7 +2141,7 @@ convention. It only has special meaning to humans. If we’re not careful,
 we might treat these abnormal values as ordinary ones and then they can
 cause havoc and dismay in our code. Haskell’s type system gives us some
 much-needed safety in that aspect. A function
-<code>a -&gt; Maybe b</code> clearly indicates that it it may produce a
+<code>a -&gt; Maybe b</code> clearly indicates that it may produce a
 <code>b</code> wrapped in <code>Just</code> or that it may return
 <code>Nothing</code>. The type is different from just plain
 <code>a -&gt; b</code> and if we try to use those two functions
@@ -2369,7 +2369,7 @@ class="label function">userError</code> to make the exception, which is
 used for making exceptions from our code and equipping them with a
 string. For instance, you can do
 <code>ioError $ userError "remote computer unplugged!"</code>, although
-It’s prefered you use types like <code>Either</code> and
+it’s preferred you use types like <code>Either</code> and
 <code>Maybe</code> to express possible failure instead of throwing
 exceptions yourself with <code>userError</code>.</p>
 <p>So you could have a handler that looks something like this:</p>

--- a/markdown/generated_html/introduction.html
+++ b/markdown/generated_html/introduction.html
@@ -42,7 +42,7 @@ floating around on the internet. When I was starting out in Haskell, I
 didn’t learn from just one resource. The way I learned it was by reading
 several different tutorials and articles because each explained
 something in a different way than the other did. By going through
-several resources, I was able put together the pieces and it all just
+several resources, I was able to put together the pieces and it all just
 came falling into place. So this is an attempt at adding another useful
 resource for learning Haskell so you have a bigger chance of finding one
 you like.</p>

--- a/markdown/generated_html/making-our-own-types-and-typeclasses.html
+++ b/markdown/generated_html/making-our-own-types-and-typeclasses.html
@@ -168,7 +168,7 @@ denote the position of the shape.</p>
 <pre class="haskell:hs"><code>ghci&gt; nudge (Circle (Point 34 34) 10) 5 10
 Circle (Point 39.0 44.0) 10.0</code></pre>
 <p>If we don’t want to deal directly with points, we can make some
-auxilliary functions that create shapes of some size at the zero
+auxiliary functions that create shapes of some size at the zero
 coordinates and then nudge those.</p>
 <pre class="haskell:hs"><code>baseCircle :: Float -&gt; Shape
 baseCircle r = Circle (Point 0 0) r
@@ -201,7 +201,7 @@ our module can make shapes by using the <code>Rectangle</code> and
 <p>We could also opt not to export any value constructors for
 <code>Shape</code> by just writing <code>Shape</code> in the export
 statement. That way, someone importing our module could only make shapes
-by using the auxilliary functions <code>baseCircle</code> and
+by using the auxiliary functions <code>baseCircle</code> and
 <code>baseRect</code>. <code>Data.Map</code> uses that approach. You
 can’t create a map by doing <code>Map.Map [(1,2),(3,4)]</code> because
 it doesn’t export that value constructor. However, you can make a
@@ -805,7 +805,7 @@ parameter and that is the type of what the integers will point to.</p>
 <p><strong>Oh yeah</strong>. If you’re going to try and implement this,
 you’ll probably going to do a qualified import of <code>Data.Map</code>.
 When you do a qualified import, type constructors also have to be
-preceeded with a module name. So you’d write
+preceded with a module name. So you’d write
 <code>type IntMap = Map.Map Int</code>.</p>
 </div>
 <p>Make sure that you really understand the distinction between type
@@ -841,7 +841,7 @@ ghci&gt; :t Left True
 Left True :: Either Bool b</code></pre>
 <p>So far, we’ve seen that <code>Maybe a</code> was mostly used to
 represent the results of computations that could have either failed or
-not. But somtimes, <code>Maybe a</code> isn’t good enough because
+not. But sometimes, <code>Maybe a</code> isn’t good enough because
 <code>Nothing</code> doesn’t really convey much information other than
 that something has failed. That’s cool for functions that can fail in
 only one way or if we’re just not interested in how and why they failed.
@@ -1032,15 +1032,15 @@ here’s what they are: an element points to two elements, one on its left
 and one on its right. The element to the left is smaller, the element to
 the right is bigger. Each of those elements can also point to two
 elements (or one, or none). In effect, each element has up to two
-sub-trees. And a cool thing about binary search trees is that we know
-that all the elements at the left sub-tree of, say, 5 are going to be
-smaller than 5. Elements in its right sub-tree are going to be bigger.
-So if we need to find if 8 is in our tree, we’d start at 5 and then
-because 8 is greater than 5, we’d go right. We’re now at 7 and because 8
-is greater than 7, we go right again. And we’ve found our element in
-three hops! Now if this were a normal list (or a tree, but really
-unbalanced), it would take us seven hops instead of three to see if 8 is
-in there.</p>
+subtrees. And a cool thing about binary search trees is that we know
+that all the elements at the left subtree of, say, 5 are going to be
+smaller than 5. Elements in its right subtree are going to be bigger. So
+if we need to find if 8 is in our tree, we’d start at 5 and then because
+8 is greater than 5, we’d go right. We’re now at 7 and because 8 is
+greater than 7, we go right again. And we’ve found our element in three
+hops! Now if this were a normal list (or a tree, but really unbalanced),
+it would take us seven hops instead of three to see if 8 is in
+there.</p>
 <p>Sets and maps from <code>Data.Set</code> and <code>Data.Map</code>
 are implemented using trees, only instead of normal binary search trees,
 they use balanced binary search trees, which are always balanced. But
@@ -1058,13 +1058,13 @@ Once we’ve reached an empty tree, we just insert a node with that value
 instead of the empty tree.</p>
 <p>In languages like C, we’d do this by modifying the pointers and
 values inside the tree. In Haskell, we can’t really modify our tree, so
-we have to make a new sub-tree each time we decide to go left or right
+we have to make a new subtree each time we decide to go left or right
 and in the end the insertion function returns a completely new tree,
 because Haskell doesn’t really have a concept of pointer, just values.
 Hence, the type for our insertion function is going to be something like
-<code>a -&gt; Tree a - &gt; Tree a</code>. It takes an element and a
-tree and returns a new tree that has that element inside. This might
-seem like it’s inefficient but laziness takes care of that problem.</p>
+<code>a -&gt; Tree a -&gt; Tree a</code>. It takes an element and a tree
+and returns a new tree that has that element inside. This might seem
+like it’s inefficient but laziness takes care of that problem.</p>
 <p>So, here are two functions. One is a utility function for making a
 singleton tree (a tree with just one node) and a function to insert an
 element into a tree.</p>
@@ -1078,15 +1078,15 @@ treeInsert x (Node a left right)
     | x &lt; a  = Node a (treeInsert x left) right
     | x &gt; a  = Node a left (treeInsert x right)</code></pre>
 <p>The <code>singleton</code> function is just a shortcut for making a
-node that has something and then two empty sub-trees. In the insertion
+node that has something and then two empty subtrees. In the insertion
 function, we first have the edge condition as a pattern. If we’ve
-reached an empty sub-tree, that means we’re where we want and instead of
+reached an empty subtree, that means we’re where we want and instead of
 the empty tree, we put a singleton tree with our element. If we’re not
 inserting into an empty tree, then we have to check some things. First
 off, if the element we’re inserting is equal to the root element, just
 return a tree that’s the same. If it’s smaller, return a tree that has
-the same root value, the same right sub-tree but instead of its left
-sub-tree, put a tree that has our value inserted into it. Same (but the
+the same root value, the same right subtree but instead of its left
+subtree, put a tree that has our value inserted into it. Same (but the
 other way around) goes if our value is bigger than the root element.</p>
 <p>Next up, we’re going to make a function that checks if some element
 is in the tree. First, let’s define the edge condition. If we’re looking
@@ -1098,8 +1098,8 @@ tree, then we check some things. If the element in the root node is what
 we’re looking for, great! If it’s not, what then? Well, we can take
 advantage of knowing that all the left elements are smaller than the
 root node. So if the element we’re looking for is smaller than the root
-node, check to see if it’s in the left sub-tree. If it’s bigger, check
-to see if it’s in the right sub-tree.</p>
+node, check to see if it’s in the left subtree. If it’s bigger, check to
+see if it’s in the right subtree.</p>
 <pre class="haskell:hs"><code>treeElem :: (Ord a) =&gt; a -&gt; Tree a -&gt; Bool
 treeElem x EmptyTree = False
 treeElem x (Node a left right)
@@ -1123,7 +1123,7 @@ and <code>EmptyTree</code> was the starting accumulator.
 <code>nums</code>, of course, was the list we were folding over.</p>
 <p>When we print our tree to the console, it’s not very readable, but if
 we try, we can make out its structure. We see that the root node is 5
-and then it has two sub-trees, one of which has the root node of 3 and
+and then it has two subtrees, one of which has the root node of 3 and
 the other a 7, etc.</p>
 <pre class="haskell:hs"><code>ghci&gt; 8 `treeElem` numsTree
 True
@@ -1197,8 +1197,8 @@ this helps us soon.</p>
 <div class="hintbox">
 <p>If we have say <code>class Eq a where</code> and then define a type
 declaration within that class like
-<code>(==) :: a -&gt; -a -&gt; Bool</code>, then when we examine the
-type of that function later on, it will have the type of
+<code>(==) :: a -&gt; a -&gt; Bool</code>, then when we examine the type
+of that function later on, it will have the type of
 <code>(Eq a) =&gt; a -&gt; a -&gt; Bool</code>.</p>
 </div>
 <p>So once we have a class, what can we do with it? Well, not much,
@@ -1595,8 +1595,8 @@ you look at <code>fmap</code> as if it were a function made only for
 <code>(a -&gt; b) -&gt; Tree a -&gt; Tree b</code>. We’re going to use
 recursion on this one. Mapping over an empty tree will produce an empty
 tree. Mapping over a non-empty tree will be a tree consisting of our
-function applied to the root value and its left and right sub-trees will
-be the previous sub-trees, only our function will be mapped over
+function applied to the root value and its left and right subtrees will
+be the previous subtrees, only our function will be mapped over
 them.</p>
 <pre class="haskell:hs"><code>instance Functor Tree where
     fmap f EmptyTree = EmptyTree
@@ -1667,8 +1667,8 @@ we use <code>fmap (\a -&gt; a)</code> (the identity function, which just
 returns its parameter) over some list, we expect to get back the same
 list as a result. For example, if we gave the wrong functor instance to
 our <code>Tree</code> type, using <code>fmap</code> over a tree where
-the left sub-tree of a node only has elements that are smaller than the
-node and the right sub-tree only has nodes that are larger than the node
+the left subtree of a node only has elements that are smaller than the
+node and the right subtree only has nodes that are larger than the node
 might produce a tree where that’s not the case. We’ll go over the
 functor laws in more detail in one of the next chapters.</p>
 </div>
@@ -1720,8 +1720,8 @@ see what the kind of that type is.</p>
 Maybe Int :: *</code></pre>
 <p>Just like I expected! We applied the type parameter to
 <code>Maybe</code> and got back a concrete type (that’s what
-<code>* -&gt; *</code> means. A parallel (although not equivalent, types
-and kinds are two different things) to this is if we do
+<code>* -&gt; *</code> means). A parallel (although not equivalent,
+types and kinds are two different things) to this is if we do
 <code>:t isUpper</code> and <code>:t isUpper 'A'</code>.
 <code>isUpper</code> has a type of <code>Char -&gt; Bool</code> and
 <code>isUpper 'A'</code> has a type of <code>Bool</code>, because its
@@ -1852,7 +1852,7 @@ it would have a type of
 <code>fmap :: (a -&gt; b) -&gt; Barry c d a -&gt; Barry c d b</code>,
 because we just replace the <code>Functor</code>’s <code>f</code> with
 <code>Barry c d</code>. The third type parameter from <code>Barry</code>
-will have to change and we see that it’s conviniently in its own
+will have to change and we see that it’s conveniently in its own
 field.</p>
 <pre class="haskell:hs"><code>instance Functor (Barry a b) where
     fmap f (Barry {yabba = x, dabba = y}) = Barry {yabba = f x, dabba = y}</code></pre>

--- a/markdown/generated_html/modules.html
+++ b/markdown/generated_html/modules.html
@@ -485,7 +485,7 @@ function names instead of old-people words.</p>
 ghci&gt; nub &quot;Lots of words and stuff&quot;
 &quot;Lots fwrdanu&quot;</code></pre>
 <p><code class="label function">delete</code> takes an element and a
-list and deletes the first occurence of that element in the list.</p>
+list and deletes the first occurrence of that element in the list.</p>
 <pre class="haskell:ghci"><code>ghci&gt; delete &#39;h&#39; &quot;hey there ghang!&quot;
 &quot;ey there ghang!&quot;
 ghci&gt; delete &#39;h&#39; . delete &#39;h&#39; $ &quot;hey there ghang!&quot;
@@ -1207,7 +1207,7 @@ the lenghts of its sides. It’s rather trivial because it’s just
 multiplication. Notice that we used it in our functions in the module
 (namely <code>cuboidArea</code> and <code>cuboidVolume</code>) but we
 didn’t export it! Because we want our module to just present functions
-for dealing with three dimensional objects, we used
+for dealing with three-dimensional objects, we used
 <code>rectangleArea</code> but we didn’t export it.</p>
 <p>When making a module, we usually export only those functions that act
 as a sort of interface to our module so that the implementation is
@@ -1221,10 +1221,10 @@ exporting them in the first place.</p>
 <pre class="haskell:ghci"><code>import Geometry</code></pre>
 <p><code>Geometry.hs</code> has to be in the same folder that the
 program that’s importing it is in, though.</p>
-<p>Modules can also be given a hierarchical structures. Each module can
-have a number of sub-modules and they can have sub-modules of their own.
-Let’s section these functions off so that <code>Geometry</code> is a
-module that has three sub-modules, one for each type of object.</p>
+<p>Modules can also have a hierarchical structure. Each module can have
+a number of submodules and they can have submodules of their own. Let’s
+section these functions off so that <code>Geometry</code> is a module
+that has three submodules, one for each type of object.</p>
 <p>First, we’ll make a folder called <code>Geometry</code>. Mind the
 capital G. In it, we’ll place three files: <code>Sphere.hs</code>,
 <code>Cuboid.hs</code>, and <code>Cube.hs</code>. Here’s what the files
@@ -1270,7 +1270,7 @@ area side = Cuboid.area side side side</code></pre>
 <p>Alright! So first is <code>Geometry.Sphere</code>. Notice how we
 placed it in a folder called <code>Geometry</code> and then defined the
 module name as <code>Geometry.Sphere</code>. We did the same for the
-cuboid. Also notice how in all three sub-modules, we defined functions
+cuboid. Also notice how in all three submodules, we defined functions
 with the same names. We can do this because they’re separate modules. We
 want to use functions from <code>Geometry.Cuboid</code> in
 <code>Geometry.Cube</code> but we can’t just straight up do

--- a/markdown/generated_html/recursion.html
+++ b/markdown/generated_html/recursion.html
@@ -247,7 +247,7 @@ check the tail. If we reach an empty list, the result is
 <h2 id="quick-sort">Quick, sort!</h2>
 <p>We have a list of items that can be sorted. Their type is an instance
 of the <code>Ord</code> typeclass. And now, we want to sort them!
-There’s a very cool algoritm for sorting called quicksort. It’s a very
+There’s a very cool algorithm for sorting called quicksort. It’s a very
 clever way of sorting items. While it takes upwards of 10 lines to
 implement quicksort in imperative languages, the implementation is much
 shorter and elegant in Haskell. Quicksort has become a sort of poster

--- a/markdown/generated_html/starting-out.html
+++ b/markdown/generated_html/starting-out.html
@@ -96,7 +96,7 @@ ghci&gt; &quot;hello&quot; == &quot;hello&quot;
 True</code></pre>
 <p>What about doing <code>5 + "llama"</code> or <code>5 == True</code>?
 Well, if we try the first snippet, we get a big scary error message!</p>
-<pre class="haskell: ghci"><code>• No instance for (Num [Char]) arising from a use of ‘+’
+<pre class="haskell: ghci"><code>• No instance for (Num String) arising from a use of ‘+’
     • In the expression: 5 + &quot;llama&quot;
       In an equation for ‘it’: it = 5 + &quot;llama&quot;</code></pre>
 <p>Yikes! What GHCI is telling us here is that <code>"llama"</code> is

--- a/markdown/generated_html/starting-out.html
+++ b/markdown/generated_html/starting-out.html
@@ -180,7 +180,7 @@ Now let’s try making our own! Open up your favorite text editor and
 punch in this function that takes a number and multiplies it by two.</p>
 <pre class="haskell: hs"><code>doubleMe x = x + x</code></pre>
 <p>Functions are defined in a similar way that they are called. The
-function name is followed by parameters seperated by spaces. But when
+function name is followed by parameters separated by spaces. But when
 defining functions, there’s a <code>=</code> and after that we define
 what the function does. Save this as <code>baby.hs</code> or something.
 Now navigate to where it’s saved and run <code>ghci</code> from there.

--- a/markdown/generated_html/syntax-in-functions.html
+++ b/markdown/generated_html/syntax-in-functions.html
@@ -193,8 +193,8 @@ tell (x:y:_) = &quot;This list is long. The first two elements are: &quot; ++ sh
 <p>This function is safe because it takes care of the empty list, a
 singleton list, a list with two elements and a list with more than two
 elements. Note that <code>(x:[])</code> and <code>(x:y:[])</code> could
-be rewriten as <code>[x]</code> and <code>[x,y]</code> (because its
-syntatic sugar, we don’t need the parentheses). We can’t rewrite
+be rewritten as <code>[x]</code> and <code>[x,y]</code> (because its
+syntactic sugar, we don’t need the parentheses). We can’t rewrite
 <code>(x:y:_)</code> with square brackets because it matches any list of
 length 2 or more.</p>
 <p>We already implemented our own <code>length</code> function using

--- a/markdown/generated_html/types-and-typeclasses.html
+++ b/markdown/generated_html/types-and-typeclasses.html
@@ -329,7 +329,7 @@ know!”.</p>
 <p><code class="label class">Enum</code> members are sequentially
 ordered types — they can be enumerated. The main advantage of the
 <code>Enum</code> typeclass is that we can use its types in list ranges.
-They also have defined successors and predecesors, which you can get
+They also have defined successors and predecessors, which you can get
 with the <code>succ</code> and <code>pred</code> functions. Types in
 this class: <code>()</code>, <code>Bool</code>, <code>Char</code>,
 <code>Ordering</code>, <code>Int</code>, <code>Integer</code>,

--- a/markdown/generated_html/zippers.html
+++ b/markdown/generated_html/zippers.html
@@ -61,8 +61,8 @@ of trees, so let’s pick a seed that we will use to plant ours. Here it
 is:</p>
 <pre class="haskell:hs"><code>data Tree a = Empty | Node a (Tree a) (Tree a) deriving (Show)</code></pre>
 <p>So our tree is either empty or it’s a node that has an element and
-two sub-trees. Here’s a fine example of such a tree, which I give to
-you, the reader, for free!</p>
+two subtrees. Here’s a fine example of such a tree, which I give to you,
+the reader, for free!</p>
 <pre class="haskell:hs"><code>freeTree :: Tree Char
 freeTree =
     Node &#39;P&#39;
@@ -99,10 +99,10 @@ changeToP (Node x l (Node y (Node _ m n) r)) = Node x l (Node y (Node &#39;P&#39
 <p>Yuck! Not only is this rather ugly, it’s also kind of confusing. What
 happens here? Well, we pattern match on our tree and name its root
 element <code>x</code> (that’s becomes the <code>'P'</code> in the root)
-and its left sub-tree <code>l</code>. Instead of giving a name to its
-right sub-tree, we further pattern match on it. We continue this pattern
-matching until we reach the sub-tree whose root is our <code>'W'</code>.
-Once we’ve done this, we rebuild the tree, only the sub-tree that
+and its left subtree <code>l</code>. Instead of giving a name to its
+right subtree, we further pattern match on it. We continue this pattern
+matching until we reach the subtree whose root is our <code>'W'</code>.
+Once we’ve done this, we rebuild the tree, only the subtree that
 contained the <code>'W'</code> at its root now has a
 <code>'P'</code>.</p>
 <p>Is there a better way of doing this? How about we make our function
@@ -117,9 +117,9 @@ changeToP :: Directions-&gt; Tree Char -&gt; Tree Char
 changeToP (L:ds) (Node x l r) = Node x (changeToP ds l) r
 changeToP (R:ds) (Node x l r) = Node x l (changeToP ds r)
 changeToP [] (Node _ l r) = Node &#39;P&#39; l r</code></pre>
-<p>If the first element in the our list of directions is <code>L</code>,
-we construct a new tree that’s like the old tree, only its left sub-tree
-has an element changed to <code>'P'</code>. When we recursively call
+<p>If the first element in the list of directions is <code>L</code>, we
+construct a new tree that’s like the old tree, only its left subtree has
+an element changed to <code>'P'</code>. When we recursively call
 <code>changeToP</code>, we give it only the tail of the list of
 directions, because we already took a left. We do the same thing in the
 case of an <code>R</code>. If the list of directions is empty, that
@@ -141,10 +141,10 @@ tree sticks:</p>
 ghci&gt; elemAt [R,L] newTree
 &#39;P&#39;</code></pre>
 <p>Nice, this seems to work. In these functions, the list of directions
-acts as a sort of <em>focus</em>, because it pinpoints one exact
-sub-tree from our tree. A direction list of <code>[R]</code> focuses on
-the sub-tree that’s right of the root, for example. An empty direction
-list focuses on the main tree itself.</p>
+acts as a sort of <em>focus</em>, because it pinpoints one exact subtree
+from our tree. A direction list of <code>[R]</code> focuses on the
+subtree that’s right of the root, for example. An empty direction list
+focuses on the main tree itself.</p>
 <p>While this technique may seem cool, it can be rather inefficient,
 especially if we want to repeatedly change elements. Say we have a
 really huge tree and a long direction list that points to some element
@@ -154,12 +154,12 @@ change another element that’s close to the element that we’ve just
 changed, we have to start from the root of the tree and walk all the way
 to the bottom again! What a drag.</p>
 <p>In the next section, we’ll find a better way of focusing on a
-sub-tree, one that allows us to efficiently switch focus to sub-trees
-that are nearby.</p>
+subtree, one that allows us to efficiently switch focus to subtrees that
+are nearby.</p>
 <h2 id="a-trail-of-breadcrumbs">A trail of breadcrumbs</h2>
 <p><img src="assets/images/zippers/bread.png" class="right" width="321"
 height="250" alt="whoop dee doo" /></p>
-<p>Okay, so for focusing on a sub-tree, we want something better than
+<p>Okay, so for focusing on a subtree, we want something better than
 just a list of directions that we always follow from the root of our
 tree. Would it help if we start at the root of the tree and move either
 left or right one step at a time and sort of leave breadcrumbs? That is,
@@ -172,12 +172,12 @@ we’ll call it <code>Breadcrumbs</code> , because our directions will now
 be reversed since we’re leaving them as we go down our tree:</p>
 <pre class="haskell:hs"><code>type Breadcrumbs = [Direction]</code></pre>
 <p>Here’s a function that takes a tree and some breadcrumbs and moves to
-the left sub-tree while adding <code>L</code> to the head of the list
+the left subtree while adding <code>L</code> to the head of the list
 that represents our breadcrumbs:</p>
 <pre class="haskell:hs"><code>goLeft :: (Tree a, Breadcrumbs) -&gt; (Tree a, Breadcrumbs)
 goLeft (Node _ l _, bs) = (l, L:bs)</code></pre>
-<p>We ignore the element at the root and the right sub-tree and just
-return the left sub-tree along with the old breadcrumbs with
+<p>We ignore the element at the root and the right subtree and just
+return the left subtree along with the old breadcrumbs with
 <code>L</code> as the head. Here’s a function to go right:</p>
 <pre class="haskell:hs"><code>goRight :: (Tree a, Breadcrumbs) -&gt; (Tree a, Breadcrumbs)
 goRight (Node _ _ r, bs) = (r, R:bs)</code></pre>
@@ -188,9 +188,9 @@ goRight (Node _ _ r, bs) = (r, R:bs)</code></pre>
 <p><img src="assets/images/zippers/almostzipper.png" class="left"
 width="399" height="224" alt="almostthere" /></p>
 <p>Okay, so now we have a tree that has <code>'W'</code> in its root and
-<code>'C'</code> in the root of its left sub-tree and <code>'R'</code>
-in the root of its right sub-tree. The breadcrumbs are
-<code>[L,R]</code>, because we first went right and then left.</p>
+<code>'C'</code> in the root of its left subtree and <code>'R'</code> in
+the root of its right subtree. The breadcrumbs are <code>[L,R]</code>,
+because we first went right and then left.</p>
 <p>To make walking along our tree clearer, we can use the
 <code>-:</code> function that we defined like so:</p>
 <pre class="haskell:hs"><code>x -: f = f x</code></pre>
@@ -204,18 +204,18 @@ left:</p>
 (Node &#39;W&#39; (Node &#39;C&#39; Empty Empty) (Node &#39;R&#39; Empty Empty),[L,R])</code></pre>
 <h3 id="going-back-up">Going back up</h3>
 <p>What if we now want to go back up in our tree? From our breadcrumbs
-we know that the current tree is the left sub-tree of its parent and
-that it is the right sub-tree of its parent, but that’s it. They don’t
-tell us enough about the parent of the current sub-tree for us to be
-able to go up in the tree. It would seem that apart from the direction
-that we took, a single breadcrumb should also contain all other data
-that we need to go back up. In this case, that’s the element in the
-parent tree along with its right sub-tree.</p>
+we know that the current tree is the left subtree of its parent and that
+it is the right subtree of its parent, but that’s it. They don’t tell us
+enough about the parent of the current subtree for us to be able to go
+up in the tree. It would seem that apart from the direction that we
+took, a single breadcrumb should also contain all other data that we
+need to go back up. In this case, that’s the element in the parent tree
+along with its right subtree.</p>
 <p>In general, a single breadcrumb should contain all the data needed to
 reconstruct the parent node. So it should have the information from all
 the paths that we didn’t take and it should also know the direction that
-we did take, but it must not contain the sub-tree that we’re currently
-focusing on. That’s because we already have that sub-tree in the first
+we did take, but it must not contain the subtree that we’re currently
+focusing on. That’s because we already have that subtree in the first
 component of the tuple, so if we also had it in the breadcrumbs, we’d
 have duplicate information.</p>
 <p>Let’s modify our breadcrumbs so that they also contain information
@@ -235,9 +235,9 @@ we took.</p>
 <p>In essence, every breadcrumb is now like a tree node with a hole in
 it. When we move deeper into a tree, the breadcrumb carries all the
 information that the node that we moved away from carried
-<em>except</em> the sub-tree that we chose to focus on. It also has to
+<em>except</em> the subtree that we chose to focus on. It also has to
 note where the hole is. In the case of a <code>LeftCrumb</code>, we know
-that we moved left, so the sub-tree that’s missing is the left one.</p>
+that we moved left, so the subtree that’s missing is the left one.</p>
 <p>Let’s also change our <code>Breadcrumbs</code> type synonym to
 reflect this:</p>
 <pre class="haskell:hs"><code>type Breadcrumbs a = [Crumb a]</code></pre>
@@ -252,17 +252,17 @@ goLeft (Node x l r, bs) = (l, LeftCrumb x r:bs)</code></pre>
 head of our list of breadcrumbs, we add a <code>LeftCrumb</code> to
 signify that we went left and we equip our <code>LeftCrumb</code> with
 the element in the node that we moved from (that’s the <code>x</code>)
-and the right sub-tree that we chose not to visit.</p>
+and the right subtree that we chose not to visit.</p>
 <p>Note that this function assumes that the current tree that’s under
-focus isn’t <code>Empty</code>. An empty tree doesn’t have any
-sub-trees, so if we try to go left from an empty tree, an error will
-occur because the pattern match on <code>Node</code> won’t succeed and
-there’s no pattern that takes care of <code>Empty</code>.</p>
+focus isn’t <code>Empty</code>. An empty tree doesn’t have any subtrees,
+so if we try to go left from an empty tree, an error will occur because
+the pattern match on <code>Node</code> won’t succeed and there’s no
+pattern that takes care of <code>Empty</code>.</p>
 <p><code>goRight</code> is similar:</p>
 <pre class="haskell:hs"><code>goRight :: (Tree a, Breadcrumbs a) -&gt; (Tree a, Breadcrumbs a)
 goRight (Node x l r, bs) = (r, RightCrumb x l:bs)</code></pre>
 <p>We were previously able to go left and right. What we’ve gotten now
-is the ability to actualy go back up by remembering stuff about the
+is the ability to actually go back up by remembering stuff about the
 parent nodes and the paths that we didn’t visit. Here’s the
 <code>goUp</code> function:</p>
 <pre class="haskell:hs"><code>goUp :: (Tree a, Breadcrumbs a) -&gt; (Tree a, Breadcrumbs a)
@@ -272,8 +272,8 @@ goUp (t, RightCrumb x l:bs) = (Node x l t, bs)</code></pre>
 width="511" height="433" alt="asstronaut" /></p>
 <p>We’re focusing on the tree <code>t</code> and we check what the
 latest <code>Crumb</code> is. If it’s a <code>LeftCrumb</code>, then we
-construct a new tree where our tree <code>t</code> is the left sub-tree
-and we use the information about the right sub-tree that we didn’t visit
+construct a new tree where our tree <code>t</code> is the left subtree
+and we use the information about the right subtree that we didn’t visit
 and the element to fill out the rest of the <code>Node</code>. Because
 we moved back so to speak and picked up the last breadcrumb to recreate
 with it the parent tree, the new list of breadcrumbs doesn’t contain
@@ -284,7 +284,7 @@ of a tree and we want to move up. Later on, we’ll use the
 focus.</p>
 <p>With a pair of <code>Tree a</code> and <code>Breadcrumbs a</code>, we
 have all the information to rebuild the whole tree and we also have a
-focus on a sub-tree. This scheme also enables us to easily move up, left
+focus on a subtree. This scheme also enables us to easily move up, left
 and right. Such a pair that contains a focused part of a data structure
 and its surroundings is called a zipper, because moving our focus up and
 down the data structure resembles the operation of a zipper on a regular
@@ -297,7 +297,7 @@ stick with <code>Zipper</code>.</p>
 <h3 id="manipulating-trees-under-focus">Manipulating trees under
 focus</h3>
 <p>Now that we can move up and down, let’s make a function that modifies
-the element in the root of the sub-tree that the zipper is focusing
+the element in the root of the subtree that the zipper is focusing
 on:</p>
 <pre class="haskell:hs"><code>modify :: (a -&gt; a) -&gt; Zipper a -&gt; Zipper a
 modify f (Node x l r, bs) = (Node (f x) l r, bs)
@@ -323,16 +323,16 @@ sort of like turning a sock inside out. That’s why when we want to move
 up, we don’t have to start from the root and make our way down, but we
 just take the top of our inverted tree, thereby uninverting a part of it
 and adding it to our focus.</p>
-<p>Each node has two sub-trees, even if those sub-trees are empty trees.
-So if we’re focusing on an empty sub-tree, one thing we can do is to
+<p>Each node has two subtrees, even if those subtrees are empty trees.
+So if we’re focusing on an empty subtree, one thing we can do is to
 replace it with a non-empty subtree, thus attaching a tree to a leaf
 node. The code for this is simple:</p>
 <pre class="haskell:hs"><code>attach :: Tree a -&gt; Zipper a -&gt; Zipper a
 attach t (_, bs) = (t, bs)</code></pre>
 <p>We take a tree and a zipper and return a new zipper that has its
 focus replaced with the supplied tree. Not only can we extend trees this
-way by replacing empty sub-trees with new trees, we can also replace
-whole existing sub-trees. Let’s attach a tree to the far left of our
+way by replacing empty subtrees with new trees, we can also replace
+whole existing subtrees. Let’s attach a tree to the far left of our
 <code>freeTree</code>:</p>
 <pre class="haskell:hs"><code>ghci&gt; let farLeft = (freeTree,[]) -: goLeft -: goLeft -: goLeft -: goLeft
 ghci&gt; let newFocus = farLeft -: attach (Node &#39;Z&#39; Empty Empty)</code></pre>
@@ -363,7 +363,7 @@ perspective.</p>
 <p>Zippers can be used with pretty much any data structure, so it’s no
 surprise that they can be used to focus on sub-lists of lists. After
 all, lists are pretty much like trees, only where a node in a tree has
-an element (or not) and several sub-trees, a node in a list has an
+an element (or not) and several subtrees, a node in a list has an
 element and only a single sub-list. When we <a
 href="making-our-own-types-and-typeclasses.html#recursive-data-structures">implemented
 our own lists</a>, we defined our data type like so:</p>
@@ -372,7 +372,7 @@ our own lists</a>, we defined our data type like so:</p>
 height="380" alt="the best damn thing" /></p>
 <p>Contrast this with our definition of our binary tree and it’s easy to
 see how lists can be viewed as trees where each node has only one
-sub-tree.</p>
+subtree.</p>
 <p>A list like <code>[1,2,3]</code> can be written as
 <code>1:2:3:[]</code>. It consists of the head of the list, which is
 <code>1</code> and then the list’s tail, which is <code>2:3:[]</code>.
@@ -382,19 +382,19 @@ and a tail, which is <code>3:[]</code>. With <code>3:[]</code>, the
 <code>[]</code>.</p>
 <p>Let’s make a zipper for lists. To change the focus on sub-lists of a
 list, we move either forward or back (whereas with trees we moved either
-up or left or right). The focused part will be a sub-tree and along with
+up or left or right). The focused part will be a subtree and along with
 that we’ll leave breadcrumbs as we move forward. Now what would a single
 breadcrumb for a list consist of? When we were dealing with binary
 trees, we said that a breadcrumb has to hold the element in the root of
-the parent node along with all the sub-trees that we didn’t choose. It
+the parent node along with all the subtrees that we didn’t choose. It
 also had to remember if we went left or right. So, it had to have all
-the information that a node has except for the sub-tree that we chose to
+the information that a node has except for the subtree that we chose to
 focus on.</p>
 <p>Lists are simpler than trees, so we don’t have to remember if we went
 left or right, because there’s only one way to go deeper into a list.
-Because there’s only one sub-tree to each node, we don’t have to
-remember the paths that we didn’t take either. It seems that all we have
-to remember is the previous element. If we have a list like
+Because there’s only one subtree to each node, we don’t have to remember
+the paths that we didn’t take either. It seems that all we have to
+remember is the previous element. If we have a list like
 <code>[3,4,5]</code> and we know that the previous element was
 <code>2</code>, we can go back by just putting that element at the head
 of our list, getting <code>[2,3,4,5]</code>.</p>
@@ -486,7 +486,7 @@ and zoom around it and add, modify and remove files as well as folders.
 Like with binary trees and lists, we’re going to be leaving breadcrumbs
 that contain info about all the stuff that we chose not to visit. Like
 we said, a single breadcrumb should be kind of like a node, only it
-should contain everything except the sub-tree that we’re currently
+should contain everything except the subtree that we’re currently
 focusing on. It should also note where the hole is so that once we move
 back up, we can plug our previous focus into the hole.</p>
 <p>In this case, a breadcrumb should be like a folder, only it should be
@@ -614,7 +614,7 @@ persistence of Haskell’s data structures really begins to shine.</p>
 binary trees, lists or file systems, we didn’t really care if we took a
 step too far and fell off. For instance, our <code>goLeft</code>
 function takes a zipper of a binary tree and moves the focus to its left
-sub-tree:</p>
+subtree:</p>
 <pre class="haskell:hs"><code>goLeft :: Zipper a -&gt; Zipper a
 goLeft (Node x l r, bs) = (l, LeftCrumb x r:bs)</code></pre>
 <p><img src="assets/images/zippers/bigtree.png" class="right"
@@ -623,9 +623,9 @@ width="247" height="367" alt="falling for you" /></p>
 is, what if it’s not a <code>Node</code>, but an <code>Empty</code>? In
 this case, we’d get a runtime error because the pattern match would fail
 and we have made no pattern to handle an empty tree, which doesn’t have
-any sub-trees at all. So far, we just assumed that we’d never try to
-focus on the left sub-tree of an empty tree as its left sub-tree doesn’t
-exist at all. But going to the left sub-tree of an empty tree doesn’t
+any subtrees at all. So far, we just assumed that we’d never try to
+focus on the left subtree of an empty tree as its left subtree doesn’t
+exist at all. But going to the left subtree of an empty tree doesn’t
 make much sense, and so far we’ve just conveniently ignored this.</p>
 <p>Or what if we were already at the root of some tree and didn’t have
 any breadcrumbs but still tried to move up? The same thing would happen.
@@ -701,12 +701,12 @@ Nothing</code></pre>
 <p>We used <code>return</code> to put a zipper in a <code>Just</code>
 and then used <code>&gt;&gt;=</code> to feed that to our
 <code>goRight</code> function. First, we made a tree that has on its
-left an empty sub-tree and on its right a node that has two empty
-sub-trees. When we try to go right once, the result is a success,
-because the operation makes sense. Going right twice is okay too; we end
-up with the focus on an empty sub-tree. But going right three times
-wouldn’t make sense, because we can’t go to the right of an empty
-sub-tree, which is why the result is a <code>Nothing</code>.</p>
+left an empty subtree and on its right a node that has two empty
+subtrees. When we try to go right once, the result is a success, because
+the operation makes sense. Going right twice is okay too; we end up with
+the focus on an empty subtree. But going right three times wouldn’t make
+sense, because we can’t go to the right of an empty subtree, which is
+why the result is a <code>Nothing</code>.</p>
 <p>Now we’ve equipped our trees with a safety-net that will catch us
 should we fall off. Wow, I nailed this metaphor.</p>
 <p>Our file system also has a lot of cases where an operation could

--- a/markdown/source_md/a-fistful-of-monads.md
+++ b/markdown/source_md/a-fistful-of-monads.md
@@ -223,7 +223,7 @@ Let's start with the first line.
 It says `class Monad m where`.
 But wait, didn't we say that monads are just beefed up applicative functors?
 Shouldn't there be a class constraint in there along the lines of `class (Applicative m) = > Monad m where` so that a type has to be an applicative functor first before it can be made a monad?
-Well, there should, but when Haskell was made, it hadn't occured to people that applicative functors are a good fit for Haskell so they weren't in there.
+Well, there should, but when Haskell was made, it hadn't occurred to people that applicative functors are a good fit for Haskell so they weren't in there.
 But rest assured, every monad is an applicative functor, even if the `Monad` class declaration doesn't say so.
 
 The first function that the `Monad` type class defines is `return`.

--- a/markdown/source_md/for-a-few-monads-more.md
+++ b/markdown/source_md/for-a-few-monads-more.md
@@ -36,7 +36,7 @@ isBigGang x = x > 9
 ```
 
 Now, what if instead of just giving us a `True` or `False` value, we want it to also return a log string that says what it did?
-Well, we just make that string and return it along side our `Bool`:
+Well, we just make that string and return it alongside our `Bool`:
 
 ```{.haskell:hs}
 isBigGang :: Int -> (Bool, String)
@@ -343,7 +343,7 @@ If it isn't, then the result is the greatest common divisor of the second number
 For instance, if we want to know what the greatest common divisor of 8 and 3 is, we just follow the algorithm outlined.
 Because 3 isn't 0, we have to find the greatest common divisor of 3 and 2 (if we divide 8 by 3, the remainder is 2).
 Next, we find the greatest common divisor of 3 and 2.
-2 still isn't 0, so now we have have 2 and 1.
+2 still isn't 0, so now we have 2 and 1.
 The second number isn't 0, so we run the algorithm again for 1 and 0, as dividing 2 by 1 gives us a remainder of 0.
 And finally, because the second number is now 0, the final result is 1.
 Let's see if our code agrees:
@@ -778,7 +778,7 @@ The actual value is the result, whereas the context is that we have to provide s
 Say we want to model operating a stack.
 You have a stack of things one on top of another and you can either push stuff on top of that stack or you can take stuff off the top of the stack.
 When you're putting an item on top of the stack we say that you're pushing it to the stack and when you're taking stuff off the top we say that you're popping it.
-If you want to something that's at the bottom of the stack, you have to pop everything that's above it.
+If you want something that's at the bottom of the stack, you have to pop everything that's above it.
 
 We'll use a list to represent our stack and the head of the list will be the top of the stack.
 To help us with our task, we'll make two functions: `pop` and `push`.
@@ -1050,7 +1050,7 @@ threeCoins = do
     return (a,b,c)
 ```
 
-`threeCoins` is now a stateful computations and after taking an initial random generator, it passes it to the first `randomSt`, which produces a number and a new generator, which gets passed to the next one and so on.
+`threeCoins` is now a stateful computation and after taking an initial random generator, it passes it to the first `randomSt`, which produces a number and a new generator, which gets passed to the next one and so on.
 We use `return (a,b,c)` to present `(a,b,c)` as the result without changing the most recent generator.
 Let's give this a go:
 
@@ -1833,7 +1833,7 @@ ghci> [(3,1%2),(5,1%4),(9,1%4)]
 Okay, so `3` has a one out of two chance of happening while `5` and `9` will happen one time out of four.
 Pretty neat.
 
-We took lists and we added some extra context to them, so this represents values withs contexts too.
+We took lists and we added some extra context to them, so this represents values with contexts too.
 Before we go any further, let's wrap this into a `newtype` because something tells me we'll be making some instances.
 
 ```{.haskell:hs}

--- a/markdown/source_md/functionally-solving-problems.md
+++ b/markdown/source_md/functionally-solving-problems.md
@@ -3,7 +3,7 @@
 In this chapter, we'll take a look at a few interesting problems and how to think functionally to solve them as elegantly as possible.
 We probably won't be introducing any new concepts, we'll just be flexing our newly acquired Haskell muscles and practicing our coding skills.
 Each section will present a different problem.
-First we'll describe the problem, then we'll try and find out what the best (or least worst) way of solving it is.
+First we'll describe the problem, then we'll try and find out what the best (or least bad) way of solving it is.
 
 ## Reverse Polish notation calculator {#reverse-polish-notation-calculator}
 
@@ -167,7 +167,7 @@ Cool, it works!
 One nice thing about this function is that it can be easily modified to support various other operators.
 They don't even have to be binary operators.
 For instance, we can make an operator `"log"` that just pops one number off the stack and pushes back its logarithm.
-We can also make a ternary operators that pop three numbers off the stack and push back a result or operators like `"sum"` which pop off all the numbers and push back their sum.
+We can also make ternary operators that pop three numbers off the stack and push back a result or operators like `"sum"` which pop off all the numbers and push back their sum.
 
 Let's modify our function to take a few more operators.
 For simplicity's sake, we'll change its type declaration so that it returns a number of type `Float`.
@@ -212,7 +212,7 @@ ghci> solveRPN "43.2425 0.5 ^"
 
 I think that making a function that can calculate arbitrary floating point RPN expressions and has the option to be easily extended in 10 lines is pretty awesome.
 
-One thing to note about this function is that it's not really fault tolerant.
+One thing to note about this function is that it's not really fault-tolerant.
 When given input that doesn't make sense, it will just crash everything.
 We'll make a fault tolerant version of this with a type declaration of `solveRPN :: String -> Maybe Float` once we get to know monads (they're not scary, trust me!).
 We could make one right now, but it would be a bit tedious because it would involve a lot of checking for `Nothing` on every step.

--- a/markdown/source_md/functors-applicative-functors-and-monoids.md
+++ b/markdown/source_md/functors-applicative-functors-and-monoids.md
@@ -124,7 +124,7 @@ It's like writing `(\xs -> intersperse '-' (reverse (map toUpper xs)))`, only pr
 Another instance of `Functor` that we've been dealing with all along but didn't know was a `Functor` is `(->) r`.
 You're probably slightly confused now, since what the heck does `(->) r` mean?
 The function type `r -> a` can be rewritten as `(->) r a`, much like we can write `2 + 3` as `(+) 2 3`.
-When we look at it as `(->) r a`, we can see `(->)` in a slighty different light, because we see that it's just a type constructor that takes two type parameters, just like `Either`.
+When we look at it as `(->) r a`, we can see `(->)` in a slightly different light, because we see that it's just a type constructor that takes two type parameters, just like `Either`.
 But remember, we said that a type constructor has to take exactly one type parameter so that it can be made an instance of `Functor`.
 That's why we can't make `(->)` an instance of `Functor`, but if we partially apply it to `(->) r`, it doesn't pose any problems.
 If the syntax allowed for type constructors to be partially applied with sections (like we can partially apply `+` by doing `(2+)`, which is the same as `(+) 2`), you could write `(->) r` as `(r ->)`.
@@ -360,7 +360,7 @@ CJust 100 [1,2,3]
 ```
 
 If we use the `CNothing` constructor, there are no fields, and if we use the `CJust` constructor, the first field is an integer and the second field can be any type.
-Let's make this an instance of `Functor` so that everytime we use `fmap`, the function gets applied to the second field, whereas the first field gets increased by 1.
+Let's make this an instance of `Functor` so that every time we use `fmap`, the function gets applied to the second field, whereas the first field gets increased by 1.
 
 ```{.haskell:hs}
 instance Functor CMaybe where
@@ -643,7 +643,7 @@ So far, we've only used `Maybe` in our examples and you might be thinking that a
 There are loads of other instances of `Applicative`, so let's go and meet them!
 
 Lists (actually the list type constructor, `[]`) are applicative functors.
-What a suprise!
+What a surprise!
 Here's how `[]` is an instance of `Applicative`:
 
 ```{.haskell:hs}
@@ -1299,13 +1299,13 @@ ghci> getPair $ fmap reverse (Pair ("london calling", 3))
 ### On newtype laziness 
 
 We mentioned that *newtype* is usually faster than *data*.
-The only thing that can be done with *newtype* is turning an existing type into a new type, so internally, Haskell can represent the values of types defined with *newtype* just like the original ones, only it has to keep in mind that the their types are now distinct.
+The only thing that can be done with *newtype* is turning an existing type into a new type, so internally, Haskell can represent the values of types defined with *newtype* just like the original ones, only it has to keep in mind that the types are now distinct.
 This fact means that not only is *newtype* faster, it's also lazier.
 Let's take a look at what this means.
 
 Like we've said before, Haskell is lazy by default, which means that only when we try to actually print the results of our functions will any computation take place.
-Furthemore, only those computations that are necessary for our function to tell us the result will get carried out.
-The `undefined` value in Haskell represents an erronous computation.
+Furthermore, only those computations that are necessary for our function to tell us the result will get carried out.
+The `undefined` value in Haskell represents an erroneous computation.
 If we try to evaluate it (that is, force Haskell to actually compute it) by printing it to the terminal, Haskell will throw a hissy fit (technically referred to as an exception):
 
 ```{.haskell:hs}
@@ -1951,7 +1951,7 @@ Trees especially lend themselves well to folding.
 
 Because there are so many data structures that work nicely with folds, the `Foldable`{.label .class} type class was introduced.
 Much like `Functor` is for things that can be mapped over, `Foldable` is for things that can be folded up!
-It can be found in `Data.Foldable` and because it export functions whose names clash with the ones from the `Prelude`, it's best imported qualified (and served with basil):
+It can be found in `Data.Foldable` and because it exports functions whose names clash with the ones from the `Prelude`, it's best imported qualified (and served with basil):
 
 ```{.haskell:hs}
 import qualified Foldable as F
@@ -2034,18 +2034,18 @@ instance F.Foldable Tree where
 ![find the visual pun or whatever](assets/images/functors-applicative-functors-and-monoids/accordion.png){.right width=366 height=280}
 
 We think like this: if we are provided with a function that takes an element of our tree and returns a monoid value, how do we reduce our whole tree down to one single monoid value?
-When we were doing `fmap` over our tree, we applied the function that we were mapping to a node and then we recursively mapped the function over the left sub-tree as well as the right one.
+When we were doing `fmap` over our tree, we applied the function that we were mapping to a node and then we recursively mapped the function over the left subtree as well as the right one.
 Here, we're tasked with not only mapping a function, but with also joining up the results into a single monoid value by using `mappend`.
-First we consider the case of the empty tree --- a sad and lonely tree that has no values or sub-trees.
+First we consider the case of the empty tree --- a sad and lonely tree that has no values or subtrees.
 It doesn't hold any value that we can give to our monoid-making function, so we just say that if our tree is empty, the monoid value it becomes is `mempty`.
 
 The case of a non-empty node is a bit more interesting.
-It contains two sub-trees as well as a value.
-In this case, we recursively `foldMap` the same function `f` over the left and the right sub-trees.
+It contains two subtrees as well as a value.
+In this case, we recursively `foldMap` the same function `f` over the left and the right subtrees.
 Remember, our `foldMap` results in a single monoid value.
 We also apply our function `f` to the value in the node.
-Now we have three monoid values (two from our sub-trees and one from applying `f` to the value in the node) and we just have to bang them together into a single value.
-For this purpose we use `mappend`, and naturally the left sub-tree comes first, then the node value and then the right sub-tree.
+Now we have three monoid values (two from our subtrees and one from applying `f` to the value in the node) and we just have to bang them together into a single value.
+For this purpose we use `mappend`, and naturally the left subtree comes first, then the node value and then the right subtree.
 
 Notice that we didn't have to provide the function that takes a value and returns a monoid value.
 We receive that function as a parameter to `foldMap` and all we have to decide is where to apply that function and how to join up the resulting monoids from it.

--- a/markdown/source_md/higher-order-functions.md
+++ b/markdown/source_md/higher-order-functions.md
@@ -83,7 +83,7 @@ compareWithHundred x = compare 100 x
 
 If we call it with `99`, it returns a `GT`.
 Simple stuff.
-Notice that the `x` is on the right hand side on both sides of the equation.
+Notice that the `x` is on the right-hand side on both sides of the equation.
 Now let's think about what `compare 100` returns.
 It returns a function that takes a number and compares it with `100`.
 Wow!
@@ -334,7 +334,7 @@ ghci> filter (`elem` ['A'..'Z']) "i Laugh At you Because u R All The Same"
 "LABRATS"
 ```
 
-All of this could also be achived with list comprehensions by the use of predicates.
+All of this could also be achieved with list comprehensions by the use of predicates.
 There's no set rule for when to use `map` and `filter` versus using list comprehension, you just have to decide what's more readable depending on the code and the context.
 The `filter` equivalent of applying several predicates in a list comprehension is either filtering something several times or joining the predicates with the logical `&&` function.
 
@@ -659,7 +659,7 @@ map' f xs = foldr (\x acc -> f x : acc) [] xs
 
 If we're mapping `(+3)` to `[1,2,3]`, we approach the list from the right side.
 We take the last element, which is `3` and apply the function to it, which ends up being `6`.
-Then, we prepend it to the accumulator, which is was `[]`.
+Then, we prepend it to the accumulator, which is `[]`.
 `6:[]` is `[6]` and that's now the accumulator.
 We apply `(+3)` to `2`, that's `5` and we prepend (`:`) it to the accumulator, so the accumulator is now `[5,6]`.
 We apply `(+3)` to `1` and prepend that to the accumulator and so the end value is `[4,5,6]`.
@@ -767,7 +767,7 @@ ghci> sum (map sqrt [1..130])
 ```
 
 We use `takeWhile` here instead of `filter` because `filter` doesn't work on infinite lists.
-Even though we know the list is ascending, `filter` doesn't, so we use `takeWhile` to cut the scanlist off at the first occurence of a sum greater than 1000.
+Even though we know the list is ascending, `filter` doesn't, so we use `takeWhile` to cut the scanlist off at the first occurrence of a sum greater than 1000.
 
 ## Function application with $ {#function-application}
 
@@ -795,7 +795,7 @@ Because `$` has such a low precedence, we can rewrite that expression as `sum $ 
 When a `$` is encountered, the expression on its right is applied as the parameter to the function on its left.
 How about `sqrt 3 + 4 + 9`?
 This adds together 9, 4 and the square root of 3.
-If we want get the square root of *3 + 4 + 9*, we'd have to write `sqrt (3 + 4 + 9)` or if we use `$` we can write it as `sqrt $ 3 + 4 + 9` because `$` has the lowest precedence of any operator.
+If we want to get the square root of *3 + 4 + 9*, we'd have to write `sqrt (3 + 4 + 9)` or if we use `$` we can write it as `sqrt $ 3 + 4 + 9` because `$` has the lowest precedence of any operator.
 That's why you can imagine a `$` being sort of the equivalent of writing an opening parentheses and then writing a closing one on the far right side of the expression.
 
 How about `sum (filter (> 10) (map (*2) [2..10]))`?
@@ -892,7 +892,7 @@ How would we write this in point free style?
 fn x = ceiling (negate (tan (cos (max 50 x))))
 ```
 
-We can't just get rid of the `x` on both right right sides.
+We can't just get rid of the `x` on both right sides.
 The `x` in the function body has parentheses after it.
 `cos (max 50)` wouldn't make sense.
 You can't get the cosine of a function.
@@ -907,7 +907,7 @@ Many times, a point free style is more readable and concise, because it makes yo
 You can take simple functions and use composition as glue to form more complex functions.
 However, many times, writing a function in point free style can be less readable if a function is too complex.
 That's why making long chains of function composition is discouraged, although I plead guilty of sometimes being too composition-happy.
-The prefered style is to use *let* bindings to give labels to intermediary results or split the problem into sub-problems and then put it together so that the function makes sense to someone reading it instead of just making a huge composition chain.
+The preferred style is to use *let* bindings to give labels to intermediary results or split the problem into sub-problems and then put it together so that the function makes sense to someone reading it instead of just making a huge composition chain.
 
 In the section about maps and filters, we solved a problem of finding the sum of all odd squares that are smaller than 10,000.
 Here's what the solution looks like when put into a function.

--- a/markdown/source_md/input-and-output.md
+++ b/markdown/source_md/input-and-output.md
@@ -33,7 +33,7 @@ And sure enough, we're going to do the good old `"hello, world"` schtick.
 ::: {.hintbox}
 **Hey!**
 For the purposes of this chapter, I'm going to assume you're using a unix-y environment for learning Haskell.
-If you're in Windows, I'd suggest you download [Cygwin](https://www.cygwin.com/), which is a Linux-like environment for Windows, A.K.A. just what you need.
+If you're on Windows, I'd suggest you download [Cygwin](https://www.cygwin.com/), which is a Linux-like environment for Windows, A.K.A. just what you need.
 :::
 
 So, for starters, punch in the following in your favorite text editor:
@@ -897,7 +897,7 @@ Same goes for writing to the terminal, it's kind of like writing to a file.
 We can call these two files `stdout` and `stdin`, meaning *standard output* and *standard input*, respectively.
 Keeping that in mind, we'll see that writing to and reading from files is very much like writing to the standard output and reading from the standard input.
 
-We'll start off with a really simple program that opens a file called *girlfriend.txt*, which contains a verse from Avril Lavigne's #1 hit *Girlfriend*, and just prints out out to the terminal.
+We'll start off with a really simple program that opens a file called *girlfriend.txt*, which contains a verse from Avril Lavigne's #1 hit *Girlfriend*, and just prints out to the terminal.
 Here's *girlfriend.txt*:
 
 ```{.plain}
@@ -1209,7 +1209,7 @@ Let's say they want to delete number 1, which is `Dust the dog`, so they punch i
 `numberString` is now `"1"` and because we want a number, not a string, we run `read` on that to get `1` and bind that to `number`.
 
 Remember the `delete` and `!!` functions from `Data.List`.
-`!!` returns an element from a list with some index and `delete` deletes the first occurence of an element in a list and returns a new list without that occurence.
+`!!` returns an element from a list with some index and `delete` deletes the first occurrence of an element in a list and returns a new list without that occurrence.
 `(todoTasks !! number)` (number is now `1`) returns `"Dust the dog"`.
 We bind `todoTasks` without the first occurence of `"Dust the dog"` to `newTodoItems` and then join that into a single string with `unlines` before writing it to the temporary file that we opened.
 The old file is now unchanged and the temporary file contains all the lines that the old one does, except the one we deleted.
@@ -1491,7 +1491,7 @@ Another cool thing about this is that it's easy to add extra functionality.
 Just add an entry in the dispatch association list and implement the corresponding function and you're laughing!
 As an exercise, you can try implementing a `bump` function that will take a file and a task number and return an I/O action that bumps that task to the top of the to-do list.
 
-You could make this program fail a bit more gracefully in case of bad input (for example, if someone runs `todo UP YOURS HAHAHAHA`) by making an I/O action that just reports there has been an error (say, `errorExit :: IO ()`) and then check for possible erronous input and if there is erronous input, perform the error reporting I/O action.
+You could make this program fail a bit more gracefully in case of bad input (for example, if someone runs `todo UP YOURS HAHAHAHA`) by making an I/O action that just reports there has been an error (say, `errorExit :: IO ()`) and then check for possible erroneous input and if there is erroneous input, perform the error reporting I/O action.
 Another way is to use exceptions, which we will meet soon.
 
 ## Randomness {#randomness}
@@ -1688,7 +1688,7 @@ Then we return the head and the rest of the list joined and the final generator 
 
 What if we want a random value in some sort of range?
 All the random integers so far were outrageously big or small.
-What if we want to to throw a die?
+What if we want to throw a die?
 Well, we use `randomR`{.label .function} for that purpose.
 It has a type of `randomR :: (RandomGen g, Random a) :: (a, a) -> g -> (a, g)`, meaning that it's kind of like `random`, only it takes as its first parameter a pair of values that set the lower and upper bounds and the final value produced will be within those bounds.
 
@@ -1714,7 +1714,7 @@ We haven't done anything concerning I/O so far.
 Well, so far we've always made our random number generator manually by making it with some arbitrary integer.
 The problem is, if we do that in our real programs, they will always return the same random numbers, which is no good for us.
 That's why `System.Random` offers the `getStdGen`{.label .function} I/O action, which has a type of `IO StdGen`.
-When your program starts, it asks the system for a good random number generator and stores that in a so called global generator.
+When your program starts, it asks the system for a good random number generator and stores that in a so-called global generator.
 `getStdGen` fetches you that global random generator when you bind it to something.
 
 Here's a simple program that generates a random string.
@@ -1822,7 +1822,7 @@ We use `read` on `numberString` to convert it to a number, so `number` is now `7
 ::: {.hintbox}
 **Excuse me!**
 If the user gives us some input here that `read` can't read (like `"haha"`), our program will crash with an ugly error message.
-If you don't want your program to crash on erronous input, use `reads`{.label .function}, which returns an empty list when it fails to read a string.
+If you don't want your program to crash on erroneous input, use `reads`{.label .function}, which returns an empty list when it fails to read a string.
 When it succeeds, it returns a singleton list with a tuple that has our desired value as one component and a string with what it didn't consume as the other.
 :::
 
@@ -1883,7 +1883,7 @@ We can just open a file and read it as a string, even though it will only be acc
 However, processing files as strings has one drawback: it tends to be slow.
 As you know, `String` is a type synonym for `[Char]`.
 `Char`s don't have a fixed size, because it takes several bytes to represent a character from, say, Unicode.
-Furthemore, lists are really lazy.
+Furthermore, lists are really lazy.
 If you have a list like `[1,2,3,4]`, it will be evaluated only when completely necessary.
 So the whole list is sort of a promise of a list.
 Remember that `[1,2,3,4]` is syntactic sugar for `1:2:3:4:[]`.
@@ -1945,7 +1945,7 @@ ghci> B.pack [98..120]
 Chunk "bcdefghijklmnopqrstuvwx" Empty
 ```
 
-As you can see, you usually don't have to worry about the `Word8` too much, because the type system can makes the numbers choose that type.
+As you can see, you usually don't have to worry about the `Word8` too much, because the type system can make the numbers choose that type.
 If you try to use a big number, like `336` as a `Word8`, it will just wrap around to `80`.
 
 We packed only a handful of values into a `ByteString`, so they fit inside one chunk.
@@ -2040,7 +2040,7 @@ In C, returning, say, `-1` on failure is completely a matter of convention.
 It only has special meaning to humans.
 If we're not careful, we might treat these abnormal values as ordinary ones and then they can cause havoc and dismay in our code.
 Haskell's type system gives us some much-needed safety in that aspect.
-A function `a -> Maybe b` clearly indicates that it it may produce a `b` wrapped in `Just` or that it may return `Nothing`.
+A function `a -> Maybe b` clearly indicates that it may produce a `b` wrapped in `Just` or that it may return `Nothing`.
 The type is different from just plain `a -> b` and if we try to use those two functions interchangeably, the compiler will complain at us.
 
 Despite having expressive types that support failed computations, Haskell still has support for exceptions, because they make more sense in I/O contexts.
@@ -2241,7 +2241,7 @@ The predicates that act on `IOError` are:
 
 Most of these are pretty self-explanatory.
 `isUserError` evaluates to `True` when we use the function `userError`{.label .function} to make the exception, which is used for making exceptions from our code and equipping them with a string.
-For instance, you can do `ioError $ userError "remote computer unplugged!"`, although It's prefered you use types like `Either` and `Maybe` to express possible failure instead of throwing exceptions yourself with `userError`.
+For instance, you can do `ioError $ userError "remote computer unplugged!"`, although it's preferred you use types like `Either` and `Maybe` to express possible failure instead of throwing exceptions yourself with `userError`.
 
 So you could have a handler that looks something like this:
 

--- a/markdown/source_md/introduction.md
+++ b/markdown/source_md/introduction.md
@@ -10,7 +10,7 @@ I decided to write this because I wanted to solidify my own knowledge of Haskell
 There are quite a few tutorials on Haskell floating around on the internet.
 When I was starting out in Haskell, I didn't learn from just one resource.
 The way I learned it was by reading several different tutorials and articles because each explained something in a different way than the other did.
-By going through several resources, I was able put together the pieces and it all just came falling into place.
+By going through several resources, I was able to put together the pieces and it all just came falling into place.
 So this is an attempt at adding another useful resource for learning Haskell so you have a bigger chance of finding one you like.
 
 ![bird](assets/images/introduction/bird.png){.left width=230 height=192}

--- a/markdown/source_md/making-our-own-types-and-typeclasses.md
+++ b/markdown/source_md/making-our-own-types-and-typeclasses.md
@@ -171,7 +171,7 @@ ghci> nudge (Circle (Point 34 34) 10) 5 10
 Circle (Point 39.0 44.0) 10.0
 ```
 
-If we don't want to deal directly with points, we can make some auxilliary functions that create shapes of some size at the zero coordinates and then nudge those.
+If we don't want to deal directly with points, we can make some auxiliary functions that create shapes of some size at the zero coordinates and then nudge those.
 
 ```{.haskell:hs}
 baseCircle :: Float -> Shape
@@ -207,7 +207,7 @@ By doing `Shape(..)`, we exported all the value constructors for `Shape`, so tha
 It's the same as writing `Shape (Rectangle, Circle)`.
 
 We could also opt not to export any value constructors for `Shape` by just writing `Shape` in the export statement.
-That way, someone importing our module could only make shapes by using the auxilliary functions `baseCircle` and `baseRect`.
+That way, someone importing our module could only make shapes by using the auxiliary functions `baseCircle` and `baseRect`.
 `Data.Map` uses that approach.
 You can't create a map by doing `Map.Map [(1,2),(3,4)]` because it doesn't export that value constructor.
 However, you can make a mapping by using one of the auxilliary functions like `Map.fromList`.
@@ -858,7 +858,7 @@ Either way, the `IntMap` type constructor takes one parameter and that is the ty
 ::: {.hintbox}
 **Oh yeah**.
 If you're going to try and implement this, you'll probably going to do a qualified import of `Data.Map`.
-When you do a qualified import, type constructors also have to be preceeded with a module name.
+When you do a qualified import, type constructors also have to be preceded with a module name.
 So you'd write `type IntMap = Map.Map Int`.
 :::
 
@@ -893,7 +893,7 @@ Left True :: Either Bool b
 ```
 
 So far, we've seen that `Maybe a` was mostly used to represent the results of computations that could have either failed or not.
-But somtimes, `Maybe a` isn't good enough because `Nothing` doesn't really convey much information other than that something has failed.
+But sometimes, `Maybe a` isn't good enough because `Nothing` doesn't really convey much information other than that something has failed.
 That's cool for functions that can fail in only one way or if we're just not interested in how and why they failed.
 A `Data.Map` lookup fails only if the key we were looking for wasn't in the map, so we know exactly what happened.
 However, when we're interested in how some function failed or why, we usually use the result type of `Either a b`, where `a` is some sort of type that can tell us something about the possible failure and `b` is the type of a successful computation.
@@ -1098,9 +1098,9 @@ Now, we're going to implement a **binary search tree**.
 If you're not familiar with binary search trees from languages like C, here's what they are: an element points to two elements, one on its left and one on its right.
 The element to the left is smaller, the element to the right is bigger.
 Each of those elements can also point to two elements (or one, or none).
-In effect, each element has up to two sub-trees.
-And a cool thing about binary search trees is that we know that all the elements at the left sub-tree of, say, 5 are going to be smaller than 5.
-Elements in its right sub-tree are going to be bigger.
+In effect, each element has up to two subtrees.
+And a cool thing about binary search trees is that we know that all the elements at the left subtree of, say, 5 are going to be smaller than 5.
+Elements in its right subtree are going to be bigger.
 So if we need to find if 8 is in our tree, we'd start at 5 and then because 8 is greater than 5, we'd go right.
 We're now at 7 and because 8 is greater than 7, we go right again.
 And we've found our element in three hops!
@@ -1123,8 +1123,8 @@ We do the same for every subsequent node until we reach an empty tree.
 Once we've reached an empty tree, we just insert a node with that value instead of the empty tree.
 
 In languages like C, we'd do this by modifying the pointers and values inside the tree.
-In Haskell, we can't really modify our tree, so we have to make a new sub-tree each time we decide to go left or right and in the end the insertion function returns a completely new tree, because Haskell doesn't really have a concept of pointer, just values.
-Hence, the type for our insertion function is going to be something like `a -> Tree a - > Tree a`.
+In Haskell, we can't really modify our tree, so we have to make a new subtree each time we decide to go left or right and in the end the insertion function returns a completely new tree, because Haskell doesn't really have a concept of pointer, just values.
+Hence, the type for our insertion function is going to be something like `a -> Tree a -> Tree a`.
 It takes an element and a tree and returns a new tree that has that element inside.
 This might seem like it's inefficient but laziness takes care of that problem.
 
@@ -1143,12 +1143,12 @@ treeInsert x (Node a left right)
     | x > a  = Node a left (treeInsert x right)
 ```
 
-The `singleton` function is just a shortcut for making a node that has something and then two empty sub-trees.
+The `singleton` function is just a shortcut for making a node that has something and then two empty subtrees.
 In the insertion function, we first have the edge condition as a pattern.
-If we've reached an empty sub-tree, that means we're where we want and instead of the empty tree, we put a singleton tree with our element.
+If we've reached an empty subtree, that means we're where we want and instead of the empty tree, we put a singleton tree with our element.
 If we're not inserting into an empty tree, then we have to check some things.
 First off, if the element we're inserting is equal to the root element, just return a tree that's the same.
-If it's smaller, return a tree that has the same root value, the same right sub-tree but instead of its left sub-tree, put a tree that has our value inserted into it.
+If it's smaller, return a tree that has the same root value, the same right subtree but instead of its left subtree, put a tree that has our value inserted into it.
 Same (but the other way around) goes if our value is bigger than the root element.
 
 Next up, we're going to make a function that checks if some element is in the tree.
@@ -1161,8 +1161,8 @@ Anyway, if we're not looking for an element in an empty tree, then we check some
 If the element in the root node is what we're looking for, great!
 If it's not, what then?
 Well, we can take advantage of knowing that all the left elements are smaller than the root node.
-So if the element we're looking for is smaller than the root node, check to see if it's in the left sub-tree.
-If it's bigger, check to see if it's in the right sub-tree.
+So if the element we're looking for is smaller than the root node, check to see if it's in the left subtree.
+If it's bigger, check to see if it's in the right subtree.
 
 ```{.haskell:hs}
 treeElem :: (Ord a) => a -> Tree a -> Bool
@@ -1190,7 +1190,7 @@ In that `foldr`, `treeInsert` was the folding function (it takes a tree and a li
 `nums`, of course, was the list we were folding over.
 
 When we print our tree to the console, it's not very readable, but if we try, we can make out its structure.
-We see that the root node is 5 and then it has two sub-trees, one of which has the root node of 3 and the other a 7, etc.
+We see that the root node is 5 and then it has two subtrees, one of which has the root node of 3 and the other a 7, etc.
 
 ```{.haskell:hs}
 ghci> 8 `treeElem` numsTree
@@ -1257,7 +1257,7 @@ We said that two instances of `Eq` are equal if they are not different and they 
 We didn't have to do this, really, but we did and we'll see how this helps us soon.
 
 ::: {.hintbox}
-If we have say `class Eq a where` and then define a type declaration within that class like `(==) :: a -> -a -> Bool`, then when we examine the type of that function later on, it will have the type of `(Eq a) => a -> a -> Bool`.
+If we have say `class Eq a where` and then define a type declaration within that class like `(==) :: a -> a -> Bool`, then when we examine the type of that function later on, it will have the type of `(Eq a) => a -> a -> Bool`.
 :::
 
 So once we have a class, what can we do with it?
@@ -1662,7 +1662,7 @@ It can be thought of as a box in a way (holds several or no values) and the `Tre
 If you look at `fmap` as if it were a function made only for `Tree`, its type signature would look like `(a -> b) -> Tree a -> Tree b`.
 We're going to use recursion on this one.
 Mapping over an empty tree will produce an empty tree.
-Mapping over a non-empty tree will be a tree consisting of our function applied to the root value and its left and right sub-trees will be the previous sub-trees, only our function will be mapped over them.
+Mapping over a non-empty tree will be a tree consisting of our function applied to the root value and its left and right subtrees will be the previous subtrees, only our function will be mapped over them.
 
 ```{.haskell:hs}
 instance Functor Tree where
@@ -1728,7 +1728,7 @@ In one of the next chapters, we'll also take a look at some laws that apply for 
 Functors should obey some laws so that they may have some properties that we can depend on and not think about too much.
 If we use `fmap (+1)` over the list `[1,2,3,4]`, we expect the result to be `[2,3,4,5]` and not its reverse, `[5,4,3,2]`.
 If we use `fmap (\a -> a)` (the identity function, which just returns its parameter) over some list, we expect to get back the same list as a result.
-For example, if we gave the wrong functor instance to our `Tree` type, using `fmap` over a tree where the left sub-tree of a node only has elements that are smaller than the node and the right sub-tree only has nodes that are larger than the node might produce a tree where that's not the case.
+For example, if we gave the wrong functor instance to our `Tree` type, using `fmap` over a tree where the left subtree of a node only has elements that are smaller than the node and the right subtree only has nodes that are larger than the node might produce a tree where that's not the case.
 We'll go over the functor laws in more detail in one of the next chapters.
 :::
 
@@ -1783,7 +1783,7 @@ Maybe Int :: *
 ```
 
 Just like I expected!
-We applied the type parameter to `Maybe` and got back a concrete type (that's what `* -> *` means.
+We applied the type parameter to `Maybe` and got back a concrete type (that's what `* -> *` means).
 A parallel (although not equivalent, types and kinds are two different things) to this is if we do `:t isUpper` and `:t isUpper 'A'`.
 `isUpper` has a type of `Char -> Bool` and `isUpper 'A'` has a type of `Bool`, because its value is basically `True`.
 Both those types, however, have a kind of `*`.
@@ -1912,7 +1912,7 @@ How satisfying.
 Now, to make this type a part of `Functor` we have to partially apply the first two type parameters so that we're left with `* -> *`.
 That means that the start of the instance declaration will be: `instance Functor (Barry a b) where`.
 If we look at `fmap` as if it was made specifically for `Barry`, it would have a type of `fmap :: (a -> b) -> Barry c d a -> Barry c d b`, because we just replace the `Functor`'s `f` with `Barry c d`.
-The third type parameter from `Barry` will have to change and we see that it's conviniently in its own field.
+The third type parameter from `Barry` will have to change and we see that it's conveniently in its own field.
 
 ```{.haskell:hs}
 instance Functor (Barry a b) where

--- a/markdown/source_md/modules.md
+++ b/markdown/source_md/modules.md
@@ -511,7 +511,7 @@ ghci> nub "Lots of words and stuff"
 "Lots fwrdanu"
 ```
 
-`delete`{.label .function} takes an element and a list and deletes the first occurence of that element in the list.
+`delete`{.label .function} takes an element and a list and deletes the first occurrence of that element in the list.
 
 ```{.haskell:ghci}
 ghci> delete 'h' "hey there ghang!"
@@ -1331,7 +1331,7 @@ Because a cube is only a special case of a cuboid, we defined its area and volum
 We also defined a helper function called `rectangleArea`, which calculates a rectangle's area based on the lenghts of its sides.
 It's rather trivial because it's just multiplication.
 Notice that we used it in our functions in the module (namely `cuboidArea` and `cuboidVolume`) but we didn't export it!
-Because we want our module to just present functions for dealing with three dimensional objects, we used `rectangleArea` but we didn't export it.
+Because we want our module to just present functions for dealing with three-dimensional objects, we used `rectangleArea` but we didn't export it.
 
 When making a module, we usually export only those functions that act as a sort of interface to our module so that the implementation is hidden.
 If someone is using our `Geometry` module, they don't have to concern themselves with functions that we don't export.
@@ -1345,9 +1345,9 @@ import Geometry
 
 `Geometry.hs` has to be in the same folder that the program that's importing it is in, though.
 
-Modules can also be given a hierarchical structures.
-Each module can have a number of sub-modules and they can have sub-modules of their own.
-Let's section these functions off so that `Geometry` is a module that has three sub-modules, one for each type of object.
+Modules can also have a hierarchical structure.
+Each module can have a number of submodules and they can have submodules of their own.
+Let's section these functions off so that `Geometry` is a module that has three submodules, one for each type of object.
 
 First, we'll make a folder called `Geometry`.
 Mind the capital G.
@@ -1408,7 +1408,7 @@ Alright!
 So first is `Geometry.Sphere`.
 Notice how we placed it in a folder called `Geometry` and then defined the module name as `Geometry.Sphere`.
 We did the same for the cuboid.
-Also notice how in all three sub-modules, we defined functions with the same names.
+Also notice how in all three submodules, we defined functions with the same names.
 We can do this because they're separate modules.
 We want to use functions from `Geometry.Cuboid` in `Geometry.Cube` but we can't just straight up do `import Geometry.Cuboid` because it exports functions with the same names as `Geometry.Cube`.
 That's why we do a qualified import and all is well.

--- a/markdown/source_md/recursion.md
+++ b/markdown/source_md/recursion.md
@@ -228,7 +228,7 @@ If we reach an empty list, the result is `False`.
 We have a list of items that can be sorted.
 Their type is an instance of the `Ord` typeclass.
 And now, we want to sort them!
-There's a very cool algoritm for sorting called quicksort.
+There's a very cool algorithm for sorting called quicksort.
 It's a very clever way of sorting items.
 While it takes upwards of 10 lines to implement quicksort in imperative languages, the implementation is much shorter and elegant in Haskell.
 Quicksort has become a sort of poster child for Haskell.

--- a/markdown/source_md/starting-out.md
+++ b/markdown/source_md/starting-out.md
@@ -173,7 +173,7 @@ doubleMe x = x + x
 ```
 
 Functions are defined in a similar way that they are called.
-The function name is followed by parameters seperated by spaces.
+The function name is followed by parameters separated by spaces.
 But when defining functions, there's a `=` and after that we define what the function does.
 Save this as `baby.hs` or something.
 Now navigate to where it's saved and run `ghci` from there.

--- a/markdown/source_md/starting-out.md
+++ b/markdown/source_md/starting-out.md
@@ -85,7 +85,7 @@ What about doing `5 + "llama"` or `5 == True`?
 Well, if we try the first snippet, we get a big scary error message!
 
 ```{.haskell: .ghci}
-• No instance for (Num [Char]) arising from a use of ‘+’
+• No instance for (Num String) arising from a use of ‘+’
     • In the expression: 5 + "llama"
       In an equation for ‘it’: it = 5 + "llama"
 ```

--- a/markdown/source_md/syntax-in-functions.md
+++ b/markdown/source_md/syntax-in-functions.md
@@ -186,7 +186,7 @@ tell (x:y:_) = "This list is long. The first two elements are: " ++ show x ++ " 
 ```
 
 This function is safe because it takes care of the empty list, a singleton list, a list with two elements and a list with more than two elements.
-Note that `(x:[])` and `(x:y:[])` could be rewriten as `[x]` and `[x,y]` (because its syntatic sugar, we don't need the parentheses).
+Note that `(x:[])` and `(x:y:[])` could be rewritten as `[x]` and `[x,y]` (because its syntactic sugar, we don't need the parentheses).
 We can't rewrite `(x:y:_)` with square brackets because it matches any list of length 2 or more.
 
 We already implemented our own `length` function using list comprehension.

--- a/markdown/source_md/types-and-typeclasses.md
+++ b/markdown/source_md/types-and-typeclasses.md
@@ -340,7 +340,7 @@ So we have to tell Haskell: "Hey, this expression should have this type, in case
 
 `Enum`{.label .class} members are sequentially ordered types --- they can be enumerated.
 The main advantage of the `Enum` typeclass is that we can use its types in list ranges.
-They also have defined successors and predecesors, which you can get with the `succ` and `pred` functions.
+They also have defined successors and predecessors, which you can get with the `succ` and `pred` functions.
 Types in this class: `()`, `Bool`, `Char`, `Ordering`, `Int`, `Integer`, `Float` and `Double`.
 
 ```{.haskell: .ghci}

--- a/markdown/source_md/zippers.md
+++ b/markdown/source_md/zippers.md
@@ -28,7 +28,7 @@ Here it is:
 data Tree a = Empty | Node a (Tree a) (Tree a) deriving (Show)
 ```
 
-So our tree is either empty or it's a node that has an element and two sub-trees.
+So our tree is either empty or it's a node that has an element and two subtrees.
 Here's a fine example of such a tree, which I give to you, the reader, for free!
 
 ```{.haskell:hs}
@@ -75,10 +75,10 @@ changeToP (Node x l (Node y (Node _ m n) r)) = Node x l (Node y (Node 'P' m n) r
 Yuck!
 Not only is this rather ugly, it's also kind of confusing.
 What happens here?
-Well, we pattern match on our tree and name its root element `x` (that's becomes the `'P'` in the root) and its left sub-tree `l`.
-Instead of giving a name to its right sub-tree, we further pattern match on it.
-We continue this pattern matching until we reach the sub-tree whose root is our `'W'`.
-Once we've done this, we rebuild the tree, only the sub-tree that contained the `'W'` at its root now has a `'P'`.
+Well, we pattern match on our tree and name its root element `x` (that's becomes the `'P'` in the root) and its left subtree `l`.
+Instead of giving a name to its right subtree, we further pattern match on it.
+We continue this pattern matching until we reach the subtree whose root is our `'W'`.
+Once we've done this, we rebuild the tree, only the subtree that contained the `'W'` at its root now has a `'P'`.
 
 Is there a better way of doing this?
 How about we make our function take a tree along with a list of directions.
@@ -95,7 +95,7 @@ changeToP (R:ds) (Node x l r) = Node x l (changeToP ds r)
 changeToP [] (Node _ l r) = Node 'P' l r
 ```
 
-If the first element in the our list of directions is `L`, we construct a new tree that's like the old tree, only its left sub-tree has an element changed to `'P'`.
+If the first element in the list of directions is `L`, we construct a new tree that's like the old tree, only its left subtree has an element changed to `'P'`.
 When we recursively call `changeToP`, we give it only the tail of the list of directions, because we already took a left.
 We do the same thing in the case of an `R`.
 If the list of directions is empty, that means that we're at our destination, so we return a tree that's like the one supplied, only it has `'P'` as its root element.
@@ -119,8 +119,8 @@ ghci> elemAt [R,L] newTree
 ```
 
 Nice, this seems to work.
-In these functions, the list of directions acts as a sort of *focus*, because it pinpoints one exact sub-tree from our tree.
-A direction list of `[R]` focuses on the sub-tree that's right of the root, for example.
+In these functions, the list of directions acts as a sort of *focus*, because it pinpoints one exact subtree from our tree.
+A direction list of `[R]` focuses on the subtree that's right of the root, for example.
 An empty direction list focuses on the main tree itself.
 
 While this technique may seem cool, it can be rather inefficient, especially if we want to repeatedly change elements.
@@ -129,13 +129,13 @@ We use the direction list to take a walk along the tree and change an element at
 If we want to change another element that's close to the element that we've just changed, we have to start from the root of the tree and walk all the way to the bottom again!
 What a drag.
 
-In the next section, we'll find a better way of focusing on a sub-tree, one that allows us to efficiently switch focus to sub-trees that are nearby.
+In the next section, we'll find a better way of focusing on a subtree, one that allows us to efficiently switch focus to subtrees that are nearby.
 
 ## A trail of breadcrumbs {#a-trail-of-breadcrumbs}
 
 ![whoop dee doo](assets/images/zippers/bread.png){.right width=321 height=250}
 
-Okay, so for focusing on a sub-tree, we want something better than just a list of directions that we always follow from the root of our tree.
+Okay, so for focusing on a subtree, we want something better than just a list of directions that we always follow from the root of our tree.
 Would it help if we start at the root of the tree and move either left or right one step at a time and sort of leave breadcrumbs?
 That is, when we go left, we remember that we went left and when we go right, we remember that we went right.
 Sure, we can try that.
@@ -146,14 +146,14 @@ To represent our breadcrumbs, we'll also use a list of `Direction` (which is eit
 type Breadcrumbs = [Direction]
 ```
 
-Here's a function that takes a tree and some breadcrumbs and moves to the left sub-tree while adding `L` to the head of the list that represents our breadcrumbs:
+Here's a function that takes a tree and some breadcrumbs and moves to the left subtree while adding `L` to the head of the list that represents our breadcrumbs:
 
 ```{.haskell:hs}
 goLeft :: (Tree a, Breadcrumbs) -> (Tree a, Breadcrumbs)
 goLeft (Node _ l _, bs) = (l, L:bs)
 ```
 
-We ignore the element at the root and the right sub-tree and just return the left sub-tree along with the old breadcrumbs with `L` as the head.
+We ignore the element at the root and the right subtree and just return the left subtree along with the old breadcrumbs with `L` as the head.
 Here's a function to go right:
 
 ```{.haskell:hs}
@@ -171,7 +171,7 @@ ghci> goLeft (goRight (freeTree, []))
 
 ![almostthere](assets/images/zippers/almostzipper.png){.left width=399 height=224}
 
-Okay, so now we have a tree that has `'W'` in its root and `'C'` in the root of its left sub-tree and `'R'` in the root of its right sub-tree.
+Okay, so now we have a tree that has `'W'` in its root and `'C'` in the root of its left subtree and `'R'` in the root of its right subtree.
 The breadcrumbs are `[L,R]`, because we first went right and then left.
 
 To make walking along our tree clearer, we can use the `-:` function that we defined like so:
@@ -192,14 +192,14 @@ ghci> (freeTree, []) -: goRight -: goLeft
 ### Going back up 
 
 What if we now want to go back up in our tree?
-From our breadcrumbs we know that the current tree is the left sub-tree of its parent and that it is the right sub-tree of its parent, but that's it.
-They don't tell us enough about the parent of the current sub-tree for us to be able to go up in the tree.
+From our breadcrumbs we know that the current tree is the left subtree of its parent and that it is the right subtree of its parent, but that's it.
+They don't tell us enough about the parent of the current subtree for us to be able to go up in the tree.
 It would seem that apart from the direction that we took, a single breadcrumb should also contain all other data that we need to go back up.
-In this case, that's the element in the parent tree along with its right sub-tree.
+In this case, that's the element in the parent tree along with its right subtree.
 
 In general, a single breadcrumb should contain all the data needed to reconstruct the parent node.
-So it should have the information from all the paths that we didn't take and it should also know the direction that we did take, but it must not contain the sub-tree that we're currently focusing on.
-That's because we already have that sub-tree in the first component of the tuple, so if we also had it in the breadcrumbs, we'd have duplicate information.
+So it should have the information from all the paths that we didn't take and it should also know the direction that we did take, but it must not contain the subtree that we're currently focusing on.
+That's because we already have that subtree in the first component of the tuple, so if we also had it in the breadcrumbs, we'd have duplicate information.
 
 Let's modify our breadcrumbs so that they also contain information about everything that we previously ignored when moving left and right.
 Instead of `Direction`, we'll make a new data type:
@@ -215,9 +215,9 @@ These breadcrumbs now contain all the data needed to recreate the tree that we w
 So instead of just being normal bread crumbs, they're now more like floppy disks that we leave as we go along, because they contain a lot more information than just the direction that we took.
 
 In essence, every breadcrumb is now like a tree node with a hole in it.
-When we move deeper into a tree, the breadcrumb carries all the information that the node that we moved away from carried *except* the sub-tree that we chose to focus on.
+When we move deeper into a tree, the breadcrumb carries all the information that the node that we moved away from carried *except* the subtree that we chose to focus on.
 It also has to note where the hole is.
-In the case of a `LeftCrumb`, we know that we moved left, so the sub-tree that's missing is the left one.
+In the case of a `LeftCrumb`, we know that we moved left, so the subtree that's missing is the left one.
 
 Let's also change our `Breadcrumbs` type synonym to reflect this:
 
@@ -233,10 +233,10 @@ goLeft :: (Tree a, Breadcrumbs a) -> (Tree a, Breadcrumbs a)
 goLeft (Node x l r, bs) = (l, LeftCrumb x r:bs)
 ```
 
-You can see that it's very similar to our previous `goLeft`, only instead of just adding a `L` to the head of our list of breadcrumbs, we add a `LeftCrumb` to signify that we went left and we equip our `LeftCrumb` with the element in the node that we moved from (that's the `x`) and the right sub-tree that we chose not to visit.
+You can see that it's very similar to our previous `goLeft`, only instead of just adding a `L` to the head of our list of breadcrumbs, we add a `LeftCrumb` to signify that we went left and we equip our `LeftCrumb` with the element in the node that we moved from (that's the `x`) and the right subtree that we chose not to visit.
 
 Note that this function assumes that the current tree that's under focus isn't `Empty`.
-An empty tree doesn't have any sub-trees, so if we try to go left from an empty tree, an error will occur because the pattern match on `Node` won't succeed and there's no pattern that takes care of `Empty`.
+An empty tree doesn't have any subtrees, so if we try to go left from an empty tree, an error will occur because the pattern match on `Node` won't succeed and there's no pattern that takes care of `Empty`.
 
 `goRight` is similar:
 
@@ -246,7 +246,7 @@ goRight (Node x l r, bs) = (r, RightCrumb x l:bs)
 ```
 
 We were previously able to go left and right.
-What we've gotten now is the ability to actualy go back up by remembering stuff about the parent nodes and the paths that we didn't visit.
+What we've gotten now is the ability to actually go back up by remembering stuff about the parent nodes and the paths that we didn't visit.
 Here's the `goUp` function:
 
 ```{.haskell:hs}
@@ -258,13 +258,13 @@ goUp (t, RightCrumb x l:bs) = (Node x l t, bs)
 ![asstronaut](assets/images/zippers/asstronaut.png){.left width=511 height=433}
 
 We're focusing on the tree `t` and we check what the latest `Crumb` is.
-If it's a `LeftCrumb`, then we construct a new tree where our tree `t` is the left sub-tree and we use the information about the right sub-tree that we didn't visit and the element to fill out the rest of the `Node`.
+If it's a `LeftCrumb`, then we construct a new tree where our tree `t` is the left subtree and we use the information about the right subtree that we didn't visit and the element to fill out the rest of the `Node`.
 Because we moved back so to speak and picked up the last breadcrumb to recreate with it the parent tree, the new list of breadcrumbs doesn't contain it.
 
 Note that this function causes an error if we're already at the top of a tree and we want to move up.
 Later on, we'll use the `Maybe` monad to represent possible failure when moving focus.
 
-With a pair of `Tree a` and `Breadcrumbs a`, we have all the information to rebuild the whole tree and we also have a focus on a sub-tree.
+With a pair of `Tree a` and `Breadcrumbs a`, we have all the information to rebuild the whole tree and we also have a focus on a subtree.
 This scheme also enables us to easily move up, left and right.
 Such a pair that contains a focused part of a data structure and its surroundings is called a zipper, because moving our focus up and down the data structure resembles the operation of a zipper on a regular pair of pants.
 So it's cool to make a type synonym as such:
@@ -277,7 +277,7 @@ I'd prefer naming the type synonym `Focus` because that makes it clearer that we
 
 ### Manipulating trees under focus 
 
-Now that we can move up and down, let's make a function that modifies the element in the root of the sub-tree that the zipper is focusing on:
+Now that we can move up and down, let's make a function that modifies the element in the root of the subtree that the zipper is focusing on:
 
 ```{.haskell:hs}
 modify :: (a -> a) -> Zipper a -> Zipper a
@@ -316,8 +316,8 @@ ghci> let newFocus2 = newFocus -: goUp -: modify (\_ -> 'X')
 Moving up is easy because the breadcrumbs that we leave form the part of the data structure that we're not focusing on, but it's inverted, sort of like turning a sock inside out.
 That's why when we want to move up, we don't have to start from the root and make our way down, but we just take the top of our inverted tree, thereby uninverting a part of it and adding it to our focus.
 
-Each node has two sub-trees, even if those sub-trees are empty trees.
-So if we're focusing on an empty sub-tree, one thing we can do is to replace it with a non-empty subtree, thus attaching a tree to a leaf node.
+Each node has two subtrees, even if those subtrees are empty trees.
+So if we're focusing on an empty subtree, one thing we can do is to replace it with a non-empty subtree, thus attaching a tree to a leaf node.
 The code for this is simple:
 
 ```{.haskell:hs}
@@ -326,7 +326,7 @@ attach t (_, bs) = (t, bs)
 ```
 
 We take a tree and a zipper and return a new zipper that has its focus replaced with the supplied tree.
-Not only can we extend trees this way by replacing empty sub-trees with new trees, we can also replace whole existing sub-trees.
+Not only can we extend trees this way by replacing empty subtrees with new trees, we can also replace whole existing subtrees.
 Let's attach a tree to the far left of our `freeTree`:
 
 ```{.haskell:hs}
@@ -355,7 +355,7 @@ So now we can walk around our tree, going left and right and up, applying `modif
 ## Focusing on lists {#focusing-on-lists}
 
 Zippers can be used with pretty much any data structure, so it's no surprise that they can be used to focus on sub-lists of lists.
-After all, lists are pretty much like trees, only where a node in a tree has an element (or not) and several sub-trees, a node in a list has an element and only a single sub-list.
+After all, lists are pretty much like trees, only where a node in a tree has an element (or not) and several subtrees, a node in a list has an element and only a single sub-list.
 When we [implemented our own lists](making-our-own-types-and-typeclasses.html#recursive-data-structures), we defined our data type like so:
 
 ```{.haskell:hs}
@@ -364,7 +364,7 @@ data List a = Empty | Cons a (List a) deriving (Show, Read, Eq, Ord)
 
 ![the best damn thing](assets/images/zippers/picard.png){.right width=355 height=380}
 
-Contrast this with our definition of our binary tree and it's easy to see how lists can be viewed as trees where each node has only one sub-tree.
+Contrast this with our definition of our binary tree and it's easy to see how lists can be viewed as trees where each node has only one subtree.
 
 A list like `[1,2,3]` can be written as `1:2:3:[]`.
 It consists of the head of the list, which is `1` and then the list's tail, which is `2:3:[]`.
@@ -373,14 +373,14 @@ With `3:[]`, the `3` is the head and the tail is the empty list `[]`.
 
 Let's make a zipper for lists.
 To change the focus on sub-lists of a list, we move either forward or back (whereas with trees we moved either up or left or right).
-The focused part will be a sub-tree and along with that we'll leave breadcrumbs as we move forward.
+The focused part will be a subtree and along with that we'll leave breadcrumbs as we move forward.
 Now what would a single breadcrumb for a list consist of?
-When we were dealing with binary trees, we said that a breadcrumb has to hold the element in the root of the parent node along with all the sub-trees that we didn't choose.
+When we were dealing with binary trees, we said that a breadcrumb has to hold the element in the root of the parent node along with all the subtrees that we didn't choose.
 It also had to remember if we went left or right.
-So, it had to have all the information that a node has except for the sub-tree that we chose to focus on.
+So, it had to have all the information that a node has except for the subtree that we chose to focus on.
 
 Lists are simpler than trees, so we don't have to remember if we went left or right, because there's only one way to go deeper into a list.
-Because there's only one sub-tree to each node, we don't have to remember the paths that we didn't take either.
+Because there's only one subtree to each node, we don't have to remember the paths that we didn't take either.
 It seems that all we have to remember is the previous element.
 If we have a list like `[3,4,5]` and we know that the previous element was `2`, we can go back by just putting that element at the head of our list, getting `[2,3,4,5]`.
 
@@ -479,7 +479,7 @@ That's actually what my disk contains right now.
 
 Now that we have a file system, all we need is a zipper so we can zip and zoom around it and add, modify and remove files as well as folders.
 Like with binary trees and lists, we're going to be leaving breadcrumbs that contain info about all the stuff that we chose not to visit.
-Like we said, a single breadcrumb should be kind of like a node, only it should contain everything except the sub-tree that we're currently focusing on.
+Like we said, a single breadcrumb should be kind of like a node, only it should contain everything except the subtree that we're currently focusing on.
 It should also note where the hole is so that once we move back up, we can plug our previous focus into the hole.
 
 In this case, a breadcrumb should be like a folder, only it should be missing the folder that we currently chose.
@@ -621,7 +621,7 @@ With zippers however, we get the ability to easily and efficiently walk around o
 ## Watch your step {#watch-your-step}
 
 So far, while walking through our data structures, whether they were binary trees, lists or file systems, we didn't really care if we took a step too far and fell off.
-For instance, our `goLeft` function takes a zipper of a binary tree and moves the focus to its left sub-tree:
+For instance, our `goLeft` function takes a zipper of a binary tree and moves the focus to its left subtree:
 
 ```{.haskell:hs}
 goLeft :: Zipper a -> Zipper a
@@ -632,9 +632,9 @@ goLeft (Node x l r, bs) = (l, LeftCrumb x r:bs)
 
 But what if the tree we're stepping off from is an empty tree?
 That is, what if it's not a `Node`, but an `Empty`?
-In this case, we'd get a runtime error because the pattern match would fail and we have made no pattern to handle an empty tree, which doesn't have any sub-trees at all.
-So far, we just assumed that we'd never try to focus on the left sub-tree of an empty tree as its left sub-tree doesn't exist at all.
-But going to the left sub-tree of an empty tree doesn't make much sense, and so far we've just conveniently ignored this.
+In this case, we'd get a runtime error because the pattern match would fail and we have made no pattern to handle an empty tree, which doesn't have any subtrees at all.
+So far, we just assumed that we'd never try to focus on the left subtree of an empty tree as its left subtree doesn't exist at all.
+But going to the left subtree of an empty tree doesn't make much sense, and so far we've just conveniently ignored this.
 
 Or what if we were already at the root of some tree and didn't have any breadcrumbs but still tried to move up?
 The same thing would happen.
@@ -718,10 +718,10 @@ Nothing
 ```
 
 We used `return` to put a zipper in a `Just` and then used `>>=` to feed that to our `goRight` function.
-First, we made a tree that has on its left an empty sub-tree and on its right a node that has two empty sub-trees.
+First, we made a tree that has on its left an empty subtree and on its right a node that has two empty subtrees.
 When we try to go right once, the result is a success, because the operation makes sense.
-Going right twice is okay too; we end up with the focus on an empty sub-tree.
-But going right three times wouldn't make sense, because we can't go to the right of an empty sub-tree, which is why the result is a `Nothing`.
+Going right twice is okay too; we end up with the focus on an empty subtree.
+But going right three times wouldn't make sense, because we can't go to the right of an empty subtree, which is why the result is a `Nothing`.
 
 Now we've equipped our trees with a safety-net that will catch us should we fall off.
 Wow, I nailed this metaphor.


### PR DESCRIPTION
This is a maintenance change to keep the markdown and generated HTML below the `/markdown` directory, whose status is in limbo at the moment, up to date with changes to the HTML in `/docs`.