### PR TITLE
Some more edits to keep the markdown version up to date

### DIFF
--- a/markdown/generated_html/functionally-solving-problems.html
+++ b/markdown/generated_html/functionally-solving-problems.html
@@ -267,7 +267,7 @@ point RPN expressions and has the option to be easily extended in 10
 lines is pretty awesome.</p>
 <p>One thing to note about this function is that it’s not really
 fault-tolerant. When given input that doesn’t make sense, it will just
-crash everything. We’ll make a fault tolerant version of this with a
+crash everything. We’ll make a fault-tolerant version of this with a
 type declaration of <code>solveRPN :: String -&gt; Maybe Float</code>
 once we get to know monads (they’re not scary, trust me!). We could make
 one right now, but it would be a bit tedious because it would involve a

--- a/markdown/generated_html/functors-applicative-functors-and-monoids.html
+++ b/markdown/generated_html/functors-applicative-functors-and-monoids.html
@@ -1557,7 +1557,7 @@ ghci&gt; getPair $ fmap reverse (Pair (&quot;london calling&quot;, 3))
 <em>data</em>. The only thing that can be done with <em>newtype</em> is
 turning an existing type into a new type, so internally, Haskell can
 represent the values of types defined with <em>newtype</em> just like
-the original ones, only it has to keep in mind that the types are now
+the original ones, only it has to keep in mind that their types are now
 distinct. This fact means that not only is <em>newtype</em> faster, it’s
 also lazier. Let’s take a look at what this means.</p>
 <p>Like we’ve said before, Haskell is lazy by default, which means that
@@ -2271,7 +2271,7 @@ values or it’s a node that holds one value and also two other trees.
 After defining it, we made it an instance of <code>Functor</code> and
 with that we gained the ability to <code>fmap</code> functions over it.
 Now, we’re going to make it an instance of <code>Foldable</code> so that
-we get the abilty to fold it up. One way to make a type constructor an
+we get the ability to fold it up. One way to make a type constructor an
 instance of <code>Foldable</code> is to just directly implement
 <code>foldr</code> for it. But another, often much easier way, is to
 implement the <code>foldMap</code> function, which is also a part of the

--- a/markdown/generated_html/higher-order-functions.html
+++ b/markdown/generated_html/higher-order-functions.html
@@ -833,7 +833,7 @@ to write <code>sqrt (3 + 4 + 9)</code> or if we use <code>$</code> we
 can write it as <code>sqrt $ 3 + 4 + 9</code> because <code>$</code> has
 the lowest precedence of any operator. That’s why you can imagine a
 <code>$</code> being sort of the equivalent of writing an opening
-parentheses and then writing a closing one on the far right side of the
+parenthesis and then writing a closing one on the far right side of the
 expression.</p>
 <p>How about <code>sum (filter (&gt; 10) (map (*2) [2..10]))</code>?
 Well, because <code>$</code> is right-associative,

--- a/markdown/generated_html/input-and-output.html
+++ b/markdown/generated_html/input-and-output.html
@@ -928,8 +928,8 @@ to and reading from files is very much like writing to the standard
 output and reading from the standard input.</p>
 <p>We’ll start off with a really simple program that opens a file called
 <em>girlfriend.txt</em>, which contains a verse from Avril Lavigne’s
-#1 hit <em>Girlfriend</em>, and just prints out to the terminal. Here’s
-<em>girlfriend.txt</em>:</p>
+#1 hit <em>Girlfriend</em>, and just prints it out to the terminal.
+Here’s <em>girlfriend.txt</em>:</p>
 <pre class="plain"><code>Hey! Hey! You! You!
 I don&#39;t like your girlfriend!
 No way! No way!
@@ -1279,7 +1279,7 @@ with some index and <code>delete</code> deletes the first occurrence of
 an element in a list and returns a new list without that occurrence.
 <code>(todoTasks !! number)</code> (number is now <code>1</code>)
 returns <code>"Dust the dog"</code>. We bind <code>todoTasks</code>
-without the first occurence of <code>"Dust the dog"</code> to
+without the first occurrence of <code>"Dust the dog"</code> to
 <code>newTodoItems</code> and then join that into a single string with
 <code>unlines</code> before writing it to the temporary file that we
 opened. The old file is now unchanged and the temporary file contains

--- a/markdown/generated_html/introduction.html
+++ b/markdown/generated_html/introduction.html
@@ -83,7 +83,7 @@ the form of functions. You also can’t set a variable to something and
 then set it to something else later. If you say that <code>a</code> is
 5, you can’t say it’s something else later because you just said it was
 5. What are you, some kind of liar? So in purely functional languages, a
-function has no side-effects. The only thing a function can do is
+function has no side effects. The only thing a function can do is
 calculate something and return it as a result. At first, this seems kind
 of limiting but it actually has some very nice consequences: if a
 function is called twice with the same parameters, it’s guaranteed to

--- a/markdown/generated_html/making-our-own-types-and-typeclasses.html
+++ b/markdown/generated_html/making-our-own-types-and-typeclasses.html
@@ -205,7 +205,7 @@ by using the auxiliary functions <code>baseCircle</code> and
 <code>baseRect</code>. <code>Data.Map</code> uses that approach. You
 can’t create a map by doing <code>Map.Map [(1,2),(3,4)]</code> because
 it doesn’t export that value constructor. However, you can make a
-mapping by using one of the auxilliary functions like
+mapping by using one of the auxiliary functions like
 <code>Map.fromList</code>. Remember, value constructors are just
 functions that take the fields as parameters and return a value of some
 type (like <code>Shape</code>) as a result. So when we choose not to
@@ -231,7 +231,7 @@ name, the third is the age and so on. Let’s make a person.</p>
 ghci&gt; guy
 Person &quot;Buddy&quot; &quot;Finklestein&quot; 43 184.2 &quot;526-2928&quot; &quot;Chocolate&quot;</code></pre>
 <p>That’s kind of cool, although slightly unreadable. What if we want to
-create a function to get seperate info from a person? A function that
+create a function to get separate info from a person? A function that
 gets some person’s first name, a function that gets some person’s last
 name, etc. Well, we’d have to define them kind of like this.</p>
 <pre class="haskell:hs"><code>firstName :: Person -&gt; String

--- a/markdown/generated_html/modules.html
+++ b/markdown/generated_html/modules.html
@@ -144,8 +144,8 @@ the list. Here’s a demonstration:</p>
 &quot;M.O.N.K.E.Y&quot;
 ghci&gt; intersperse 0 [1,2,3,4,5,6]
 [1,0,2,0,3,0,4,0,5,0,6]</code></pre>
-<p><code class="label function">intercalate</code> takes a list of lists
-and a list. It then inserts that list in between all those lists and
+<p><code class="label function">intercalate</code> takes a list and a
+list of lists. It then inserts that list in between all those lists and
 then flattens the result.</p>
 <pre class="haskell:ghci"><code>ghci&gt; intercalate &quot; &quot; [&quot;hey&quot;,&quot;there&quot;,&quot;guys&quot;]
 &quot;hey there guys&quot;
@@ -402,7 +402,7 @@ our stock never went over $1000? Our application of
 of an empty list would result in an error. However, if we rewrote that
 as <code>find (\(val,y,m,d) -&gt; val &gt; 1000) stock</code>, we’d be
 much safer. If our stock never went over $1000 (so if no element
-satisfied the predicate), we’d get back a <code>Nothing</code>. But
+satisfied the predicate), we’d get back a <code>Nothing</code>. But if
 there was a valid answer in that list, we’d get, say,
 <code>Just (1001.4,2008,9,4)</code>.</p>
 <p><code class="label function">elemIndex</code> is kind of like
@@ -455,7 +455,7 @@ ghci&gt; zip4 [2,3,3] [2,2,2] [5,5,3] [2,2,2]
 shortest list that’s being zipped are cut down to size.</p>
 <p><code class="label function">lines</code> is a useful function when
 dealing with files or input from somewhere. It takes a string and
-returns every line of that string in a separate list.</p>
+returns every line of that string as separate element of a list.</p>
 <pre class="haskell:ghci"><code>ghci&gt; lines &quot;first line\nsecond line\nthird line&quot;
 [&quot;first line&quot;,&quot;second line&quot;,&quot;third line&quot;]</code></pre>
 <p><code>'\n'</code> is the character for a unix newline. Backslashes
@@ -673,7 +673,7 @@ character is a hex digit.</p>
 character is a letter.</p>
 <p><code class="label function">isMark</code> checks for Unicode mark
 characters. Those are characters that combine with preceding letters to
-form latters with accents. Use this if you are French.</p>
+form letters with accents. Use this if you are French.</p>
 <p><code class="label function">isNumber</code> checks whether a
 character is numeric.</p>
 <p><code class="label function">isPunctuation</code> checks whether a
@@ -959,8 +959,8 @@ fromList [(3,9),(5,9)]</code></pre>
 <code>Data.List</code> <code>lookup</code>, only it operates on maps. It
 returns <code>Just something</code> if it finds something for the key
 and <code>Nothing</code> if it doesn’t.</p>
-<p><code class="label function">member</code> is a predicate takes a key
-and a map and reports whether the key is in the map or not.</p>
+<p><code class="label function">member</code> is a predicate that takes
+a key and a map and reports whether the key is in the map or not.</p>
 <pre class="haskell:ghci"><code>ghci&gt; Map.member 3 $ Map.fromList [(3,6),(4,3),(6,9)]
 True
 ghci&gt; Map.member 3 $ Map.fromList [(2,5),(4,5)]

--- a/markdown/generated_html/zippers.html
+++ b/markdown/generated_html/zippers.html
@@ -117,7 +117,7 @@ changeToP :: Directions-&gt; Tree Char -&gt; Tree Char
 changeToP (L:ds) (Node x l r) = Node x (changeToP ds l) r
 changeToP (R:ds) (Node x l r) = Node x l (changeToP ds r)
 changeToP [] (Node _ l r) = Node &#39;P&#39; l r</code></pre>
-<p>If the first element in the list of directions is <code>L</code>, we
+<p>If the first element in our list of directions is <code>L</code>, we
 construct a new tree that’s like the old tree, only its left subtree has
 an element changed to <code>'P'</code>. When we recursively call
 <code>changeToP</code>, we give it only the tail of the list of

--- a/markdown/source_md/functionally-solving-problems.md
+++ b/markdown/source_md/functionally-solving-problems.md
@@ -214,7 +214,7 @@ I think that making a function that can calculate arbitrary floating point RPN e
 
 One thing to note about this function is that it's not really fault-tolerant.
 When given input that doesn't make sense, it will just crash everything.
-We'll make a fault tolerant version of this with a type declaration of `solveRPN :: String -> Maybe Float` once we get to know monads (they're not scary, trust me!).
+We'll make a fault-tolerant version of this with a type declaration of `solveRPN :: String -> Maybe Float` once we get to know monads (they're not scary, trust me!).
 We could make one right now, but it would be a bit tedious because it would involve a lot of checking for `Nothing` on every step.
 If you're feeling up to the challenge though, you can go ahead and try it!
 Hint: you can use `reads` to see if a read was successful or not.

--- a/markdown/source_md/functors-applicative-functors-and-monoids.md
+++ b/markdown/source_md/functors-applicative-functors-and-monoids.md
@@ -1299,7 +1299,7 @@ ghci> getPair $ fmap reverse (Pair ("london calling", 3))
 ### On newtype laziness 
 
 We mentioned that *newtype* is usually faster than *data*.
-The only thing that can be done with *newtype* is turning an existing type into a new type, so internally, Haskell can represent the values of types defined with *newtype* just like the original ones, only it has to keep in mind that the types are now distinct.
+The only thing that can be done with *newtype* is turning an existing type into a new type, so internally, Haskell can represent the values of types defined with *newtype* just like the original ones, only it has to keep in mind that their types are now distinct.
 This fact means that not only is *newtype* faster, it's also lazier.
 Let's take a look at what this means.
 
@@ -2004,7 +2004,7 @@ data Tree a = Empty | Node a (Tree a) (Tree a) deriving (Show, Read, Eq)
 
 We said that a tree is either an empty tree that doesn't hold any values or it's a node that holds one value and also two other trees.
 After defining it, we made it an instance of `Functor` and with that we gained the ability to `fmap` functions over it.
-Now, we're going to make it an instance of `Foldable` so that we get the abilty to fold it up.
+Now, we're going to make it an instance of `Foldable` so that we get the ability to fold it up.
 One way to make a type constructor an instance of `Foldable` is to just directly implement `foldr` for it.
 But another, often much easier way, is to implement the `foldMap` function, which is also a part of the `Foldable` type class.
 The `foldMap` function has the following type:

--- a/markdown/source_md/higher-order-functions.md
+++ b/markdown/source_md/higher-order-functions.md
@@ -796,7 +796,7 @@ When a `$` is encountered, the expression on its right is applied as the paramet
 How about `sqrt 3 + 4 + 9`?
 This adds together 9, 4 and the square root of 3.
 If we want to get the square root of *3 + 4 + 9*, we'd have to write `sqrt (3 + 4 + 9)` or if we use `$` we can write it as `sqrt $ 3 + 4 + 9` because `$` has the lowest precedence of any operator.
-That's why you can imagine a `$` being sort of the equivalent of writing an opening parentheses and then writing a closing one on the far right side of the expression.
+That's why you can imagine a `$` being sort of the equivalent of writing an opening parenthesis and then writing a closing one on the far right side of the expression.
 
 How about `sum (filter (> 10) (map (*2) [2..10]))`?
 Well, because `$` is right-associative, `f (g (z x))` is equal to `f $ g $ z x`.

--- a/markdown/source_md/input-and-output.md
+++ b/markdown/source_md/input-and-output.md
@@ -897,7 +897,7 @@ Same goes for writing to the terminal, it's kind of like writing to a file.
 We can call these two files `stdout` and `stdin`, meaning *standard output* and *standard input*, respectively.
 Keeping that in mind, we'll see that writing to and reading from files is very much like writing to the standard output and reading from the standard input.
 
-We'll start off with a really simple program that opens a file called *girlfriend.txt*, which contains a verse from Avril Lavigne's #1 hit *Girlfriend*, and just prints out to the terminal.
+We'll start off with a really simple program that opens a file called *girlfriend.txt*, which contains a verse from Avril Lavigne's #1 hit *Girlfriend*, and just prints it out to the terminal.
 Here's *girlfriend.txt*:
 
 ```{.plain}
@@ -1211,7 +1211,7 @@ Let's say they want to delete number 1, which is `Dust the dog`, so they punch i
 Remember the `delete` and `!!` functions from `Data.List`.
 `!!` returns an element from a list with some index and `delete` deletes the first occurrence of an element in a list and returns a new list without that occurrence.
 `(todoTasks !! number)` (number is now `1`) returns `"Dust the dog"`.
-We bind `todoTasks` without the first occurence of `"Dust the dog"` to `newTodoItems` and then join that into a single string with `unlines` before writing it to the temporary file that we opened.
+We bind `todoTasks` without the first occurrence of `"Dust the dog"` to `newTodoItems` and then join that into a single string with `unlines` before writing it to the temporary file that we opened.
 The old file is now unchanged and the temporary file contains all the lines that the old one does, except the one we deleted.
 
 After that we close both the original and the temporary files and then we remove the original one with `removeFile`{.label .function}, which, as you can see, takes a path to a file and deletes it.

--- a/markdown/source_md/introduction.md
+++ b/markdown/source_md/introduction.md
@@ -41,7 +41,7 @@ You express that in the form of functions.
 You also can't set a variable to something and then set it to something else later.
 If you say that `a` is 5, you can't say it's something else later because you just said it was 5.
 What are you, some kind of liar?
-So in purely functional languages, a function has no side-effects.
+So in purely functional languages, a function has no side effects.
 The only thing a function can do is calculate something and return it as a result.
 At first, this seems kind of limiting but it actually has some very nice consequences: if a function is called twice with the same parameters, it's guaranteed to return the same result.
 That's called referential transparency and not only does it allow the compiler to reason about the program's behavior, but it also allows you to easily deduce (and even prove) that a function is correct and then build more complex functions by gluing simple functions together.

--- a/markdown/source_md/making-our-own-types-and-typeclasses.md
+++ b/markdown/source_md/making-our-own-types-and-typeclasses.md
@@ -210,7 +210,7 @@ We could also opt not to export any value constructors for `Shape` by just writi
 That way, someone importing our module could only make shapes by using the auxiliary functions `baseCircle` and `baseRect`.
 `Data.Map` uses that approach.
 You can't create a map by doing `Map.Map [(1,2),(3,4)]` because it doesn't export that value constructor.
-However, you can make a mapping by using one of the auxilliary functions like `Map.fromList`.
+However, you can make a mapping by using one of the auxiliary functions like `Map.fromList`.
 Remember, value constructors are just functions that take the fields as parameters and return a value of some type (like `Shape`) as a result.
 So when we choose not to export them, we just prevent the person importing our module from using those functions, but if some other functions that are exported return a type, we can use them to make values of our custom data types.
 
@@ -241,7 +241,7 @@ Person "Buddy" "Finklestein" 43 184.2 "526-2928" "Chocolate"
 ```
 
 That's kind of cool, although slightly unreadable.
-What if we want to create a function to get seperate info from a person?
+What if we want to create a function to get separate info from a person?
 A function that gets some person's first name, a function that gets some person's last name, etc.
 Well, we'd have to define them kind of like this.
 

--- a/markdown/source_md/modules.md
+++ b/markdown/source_md/modules.md
@@ -109,7 +109,7 @@ ghci> intersperse 0 [1,2,3,4,5,6]
 [1,0,2,0,3,0,4,0,5,0,6]
 ```
 
-`intercalate`{.label .function} takes a list of lists and a list.
+`intercalate`{.label .function} takes a list and a list of lists.
 It then inserts that list in between all those lists and then flattens the result.
 
 ```{.haskell:ghci}
@@ -414,7 +414,7 @@ What would happen if our stock never went over $1000?
 Our application of `dropWhile` would return an empty list and getting the head of an empty list would result in an error.
 However, if we rewrote that as `find (\(val,y,m,d) -> val > 1000) stock`, we'd be much safer.
 If our stock never went over $1000 (so if no element satisfied the predicate), we'd get back a `Nothing`.
-But there was a valid answer in that list, we'd get, say, `Just (1001.4,2008,9,4)`.
+But if there was a valid answer in that list, we'd get, say, `Just (1001.4,2008,9,4)`.
 
 `elemIndex`{.label .function} is kind of like `elem`, only it doesn't return a boolean value.
 It maybe returns the index of the element we're looking for.
@@ -468,7 +468,7 @@ ghci> zip4 [2,3,3] [2,2,2] [5,5,3] [2,2,2]
 Just like with normal zipping, lists that are longer than the shortest list that's being zipped are cut down to size.
 
 `lines`{.label .function} is a useful function when dealing with files or input from somewhere.
-It takes a string and returns every line of that string in a separate list.
+It takes a string and returns every line of that string as separate element of a list.
 
 ```{.haskell:ghci}
 ghci> lines "first line\nsecond line\nthird line"
@@ -685,7 +685,7 @@ Control characters, for instance, are not printable.
 `isLetter`{.label .function} checks whether a character is a letter.
 
 `isMark`{.label .function} checks for Unicode mark characters.
-Those are characters that combine with preceding letters to form latters with accents.
+Those are characters that combine with preceding letters to form letters with accents.
 Use this if you are French.
 
 `isNumber`{.label .function} checks whether a character is numeric.
@@ -1032,7 +1032,7 @@ fromList [(3,9),(5,9)]
 `lookup`{.label .function} works like the `Data.List` `lookup`, only it operates on maps.
 It returns `Just something` if it finds something for the key and `Nothing` if it doesn't.
 
-`member`{.label .function} is a predicate takes a key and a map and reports whether the key is in the map or not.
+`member`{.label .function} is a predicate that takes a key and a map and reports whether the key is in the map or not.
 
 ```{.haskell:ghci}
 ghci> Map.member 3 $ Map.fromList [(3,6),(4,3),(6,9)]

--- a/markdown/source_md/zippers.md
+++ b/markdown/source_md/zippers.md
@@ -95,7 +95,7 @@ changeToP (R:ds) (Node x l r) = Node x l (changeToP ds r)
 changeToP [] (Node _ l r) = Node 'P' l r
 ```
 
-If the first element in the list of directions is `L`, we construct a new tree that's like the old tree, only its left subtree has an element changed to `'P'`.
+If the first element in our list of directions is `L`, we construct a new tree that's like the old tree, only its left subtree has an element changed to `'P'`.
 When we recursively call `changeToP`, we give it only the tail of the list of directions, because we already took a left.
 We do the same thing in the case of an `R`.
 If the list of directions is empty, that means that we're at our destination, so we return a tree that's like the one supplied, only it has `'P'` as its root element.


### PR DESCRIPTION
After checking the differences between the markdown and original HTML systematically, I found some more places where typos or grammar had been corrected in the `docs` folder but not in the markdown version. This pull request adds the remaining changes.