### PR TITLE
Fix output of transpose after "guys" -> "folks" change

### DIFF
--- a/docs/making-our-own-types-and-typeclasses.html
+++ b/docs/making-our-own-types-and-typeclasses.html
@@ -31,134 +31,210 @@
                                             </li>
                 </ul>
             </div>
-        <h1>Making Our Own Types and Typeclasses</h1>
-<p>In the previous chapters, we covered some existing Haskell types and typeclasses. In this chapter, we'll learn how to make our own and how to put them to work!</p>
-<a name="algebraic-data-types"></a><h2>Algebraic data types intro</h2>
-<p>So far, we've run into a lot of data types. <span class="fixed">Bool</span>, <span class="fixed">Int</span>, <span class="fixed">Char</span>, <span class="fixed">Maybe</span>, etc. But how do we make our own? Well, one way is to use the <em>data</em> keyword to define a type. Let's see how the <span class="fixed">Bool</span> type is defined in the standard library.</p>
-<pre name="code" class="haskell:hs">
-data Bool = False | True
-</pre>
-<p><span class="fixed">data</span> means that we're defining a new data type. The part before the <span class="fixed">=</span> denotes the type, which is <span class="fixed">Bool</span>. The parts after the <span class="fixed">=</span> are <em>value constructors</em>. They specify the different values that this type can have. The <span class="fixed">|</span> is read as <i>or</i>. So we can read this as: the <span class="fixed">Bool</span> type can have a value of <span class="fixed">True</span> or <span class="fixed">False</span>. Both the type name and the value constructors have to be capital cased.</p>
-<p>In a similar fashion, we can think of the <span class="fixed">Int</span> type as being defined like this:</p>
-<pre name="code" class="haskell:hs">
-data Int = -2147483648 | -2147483647 | ... | -1 | 0 | 1 | 2 | ... | 2147483647
-</pre>
-<img src="assets/images/making-our-own-types-and-typeclasses/caveman.png" alt="caveman" class="left" width="220" height="215">
-<p>The first and last value constructors are the minimum and maximum possible values of <span class="fixed">Int</span>. It's not actually defined like this, the ellipses are here because we omitted a heapload of numbers, so this is just for illustrative purposes.</p>
-<p>Now, let's think about how we would represent a shape in Haskell. One way would be to use tuples. A circle could be denoted as <span class="fixed">(43.1, 55.0, 10.4)</span> where the first and second fields are the coordinates of the circle's center and the third field is the radius. Sounds OK, but those could also represent a 3D vector or anything else. A better solution would be to make our own type to represent a shape. Let's say that a shape can be a circle or a rectangle. Here it is:</p>
-<pre name="code" class="haskell:hs">
-data Shape = Circle Float Float Float | Rectangle Float Float Float Float
-</pre>
-<p>
-Now what's this? Think of it like this. The <span class="fixed">Circle</span> value constructor has three fields, which take floats. So when we write a value constructor, we can optionally add some types after it and those types define the values it will contain. Here, the first two fields are the coordinates of its center, the third one its radius. The <span class="fixed">Rectangle</span> value constructor has four fields which accept floats. The first two are the coordinates to its upper left corner and the second two are coordinates to its lower right one.
-</p>
-<p>Now when I say fields, I actually mean parameters. Value constructors are actually functions that ultimately return a value of a data type. Let's take a look at the type signatures for these two value constructors.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; :t Circle
+<h1 id="making-our-own-types-and-typeclasses">Making Our Own Types and
+Typeclasses</h1>
+<p>In the previous chapters, we covered some existing Haskell types and
+typeclasses. In this chapter, we’ll learn how to make our own and how to
+put them to work!</p>
+<h2 id="algebraic-data-types">Algebraic data types intro</h2>
+<p>So far, we’ve run into a lot of data types. <code>Bool</code>,
+<code>Int</code>, <code>Char</code>, <code>Maybe</code>, etc. But how do
+we make our own? Well, one way is to use the <strong>data</strong>
+keyword to define a type. Let’s see how the <code>Bool</code> type is
+defined in the standard library.</p>
+<pre class="haskell:hs"><code>data Bool = False | True</code></pre>
+<p><code>data</code> means that we’re defining a new data type. The part
+before the <code>=</code> denotes the type, which is <code>Bool</code>.
+The parts after the <code>=</code> are <strong>value
+constructors</strong>. They specify the different values that this type
+can have. The <code>|</code> is read as <em>or</em>. So we can read this
+as: the <code>Bool</code> type can have a value of <code>True</code> or
+<code>False</code>. Both the type name and the value constructors have
+to be capital cased.</p>
+<p>In a similar fashion, we can think of the <code>Int</code> type as
+being defined like this:</p>
+<pre class="haskell:hs"><code>data Int = -2147483648 | -2147483647 | ... | -1 | 0 | 1 | 2 | ... | 2147483647</code></pre>
+<p><img
+src="assets/images/making-our-own-types-and-typeclasses/caveman.png"
+class="left" width="220" height="215" alt="caveman" /></p>
+<p>The first and last value constructors are the minimum and maximum
+possible values of <code>Int</code>. It’s not actually defined like
+this, the ellipses are here because we omitted a heapload of numbers, so
+this is just for illustrative purposes.</p>
+<p>Now, let’s think about how we would represent a shape in Haskell. One
+way would be to use tuples. A circle could be denoted as
+<code>(43.1, 55.0, 10.4)</code> where the first and second fields are
+the coordinates of the circle’s center and the third field is the
+radius. Sounds OK, but those could also represent a 3D vector or
+anything else. A better solution would be to make our own type to
+represent a shape. Let’s say that a shape can be a circle or a
+rectangle. Here it is:</p>
+<pre class="haskell:hs"><code>data Shape = Circle Float Float Float | Rectangle Float Float Float Float</code></pre>
+<p>Now what’s this? Think of it like this. The <code>Circle</code> value
+constructor has three fields, which take floats. So when we write a
+value constructor, we can optionally add some types after it and those
+types define the values it will contain. Here, the first two fields are
+the coordinates of its center, the third one its radius. The
+<code>Rectangle</code> value constructor has four fields which accept
+floats. The first two are the coordinates to its upper left corner and
+the second two are coordinates to its lower right one.</p>
+<p>Now when I say fields, I actually mean parameters. Value constructors
+are actually functions that ultimately return a value of a data type.
+Let’s take a look at the type signatures for these two value
+constructors.</p>
+<pre class="haskell:hs"><code>ghci&gt; :t Circle
 Circle :: Float -&gt; Float -&gt; Float -&gt; Shape
 ghci&gt; :t Rectangle
-Rectangle :: Float -&gt; Float -&gt; Float -&gt; Float -&gt; Shape
-</pre>
-<p>Cool, so value constructors are functions like everything else. Who would have thought? Let's make a function that takes a shape and returns its surface.</p>
-<pre name="code" class="haskell:hs">
-surface :: Shape -&gt; Float
+Rectangle :: Float -&gt; Float -&gt; Float -&gt; Float -&gt; Shape</code></pre>
+<p>Cool, so value constructors are functions like everything else. Who
+would have thought? Let’s make a function that takes a shape and returns
+its surface.</p>
+<pre class="haskell:hs"><code>surface :: Shape -&gt; Float
 surface (Circle _ _ r) = pi * r ^ 2
-surface (Rectangle x1 y1 x2 y2) = (abs $ x2 - x1) * (abs $ y2 - y1)
-</pre>
-<p>The first notable thing here is the type declaration. It says that the function takes a shape and returns a float. We couldn't write a type declaration of <span class="fixed">Circle -&gt; Float</span> because <span class="fixed">Circle</span> is not a type, <span class="fixed">Shape</span> is. Just like we can't write a function with a type declaration of <span class="fixed">True -&gt; Int</span>. The next thing we notice here is that we can pattern match against constructors. We pattern matched against constructors before (all the time actually) when we pattern matched against values like <span class="fixed">[]</span> or <span class="fixed">False</span> or <span class="fixed">5</span>, only those values didn't have any fields. We just write a constructor and then bind its fields to names. Because we're interested in the radius, we don't actually care about the first two fields, which tell us where the circle is.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; surface $ Circle 10 20 10
+surface (Rectangle x1 y1 x2 y2) = (abs $ x2 - x1) * (abs $ y2 - y1)</code></pre>
+<p>The first notable thing here is the type declaration. It says that
+the function takes a shape and returns a float. We couldn’t write a type
+declaration of <code>Circle -&gt; Float</code> because
+<code>Circle</code> is not a type, <code>Shape</code> is. Just like we
+can’t write a function with a type declaration of
+<code>True -&gt; Int</code>. The next thing we notice here is that we
+can pattern match against constructors. We pattern matched against
+constructors before (all the time actually) when we pattern matched
+against values like <code>[]</code> or <code>False</code> or
+<code>5</code>, only those values didn’t have any fields. We just write
+a constructor and then bind its fields to names. Because we’re
+interested in the radius, we don’t actually care about the first two
+fields, which tell us where the circle is.</p>
+<pre class="haskell:hs"><code>ghci&gt; surface $ Circle 10 20 10
 314.15927
 ghci&gt; surface $ Rectangle 0 0 100 100
-10000.0
-</pre>
-<p>Yay, it works! But if we try to just print out <span class="fixed">Circle 10 20 5</span> in the prompt, we'll get an error. That's because Haskell doesn't know how to display our data type as a string (yet). Remember, when we try to print a value out in the prompt, Haskell first runs the <span class="fixed">show</span> function to get the string representation of our value and then it prints that out to the terminal. To make our <span class="fixed">Shape</span> type part of the <span class="fixed">Show</span> typeclass, we modify it like this: </p>
-<pre name="code" class="haskell:hs">
-data Shape = Circle Float Float Float | Rectangle Float Float Float Float deriving (Show)
-</pre>
-<p>We won't concern ourselves with deriving too much for now. Let's just say that if we add <span class="fixed">deriving (Show)</span> at the end of a <i>data</i> declaration, Haskell automagically makes that type part of the <span class="fixed">Show</span> typeclass. So now, we can do this:</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; Circle 10 20 5
+10000.0</code></pre>
+<p>Yay, it works! But if we try to just print out
+<code>Circle 10 20 5</code> in the prompt, we’ll get an error. That’s
+because Haskell doesn’t know how to display our data type as a string
+(yet). Remember, when we try to print a value out in the prompt, Haskell
+first runs the <code>show</code> function to get the string
+representation of our value and then it prints that out to the terminal.
+To make our <code>Shape</code> type part of the <code>Show</code>
+typeclass, we modify it like this:</p>
+<pre class="haskell:hs"><code>data Shape = Circle Float Float Float | Rectangle Float Float Float Float deriving (Show)</code></pre>
+<p>We won’t concern ourselves with deriving too much for now. Let’s just
+say that if we add <code>deriving (Show)</code> at the end of a
+<em>data</em> declaration, Haskell automagically makes that type part of
+the <code>Show</code> typeclass. So now, we can do this:</p>
+<pre class="haskell:hs"><code>ghci&gt; Circle 10 20 5
 Circle 10.0 20.0 5.0
 ghci&gt; Rectangle 50 230 60 90
-Rectangle 50.0 230.0 60.0 90.0
-</pre>
-<p>Value constructors are functions, so we can map them and partially apply them and everything. If we want a list of concentric circles with different radii, we can do this.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; map (Circle 10 20) [4,5,6,6]
-[Circle 10.0 20.0 4.0,Circle 10.0 20.0 5.0,Circle 10.0 20.0 6.0,Circle 10.0 20.0 6.0]
-</pre>
-<p>Our data type is good, although it could be better. Let's make an intermediate data type that defines a point in two-dimensional space. Then we can use that to make our shapes more understandable.</p>
-<pre name="code" class="haskell:hs">
-data Point = Point Float Float deriving (Show)
-data Shape = Circle Point Float | Rectangle Point Point deriving (Show)
-</pre>
-<p>Notice that when defining a point, we used the same name for the data type and the value constructor. This has no special meaning, although it's common to use the same name as the type if there's only one value constructor. So now the <span class="fixed">Circle</span> has two fields, one is of type <span class="fixed">Point</span> and the other of type <span class="fixed">Float</span>. This makes it easier to understand what's what. Same goes for the rectangle. We have to adjust our <span class="fixed">surface</span> function to reflect these changes.</p>
-<pre name="code" class="haskell:hs">
-surface :: Shape -> Float
+Rectangle 50.0 230.0 60.0 90.0</code></pre>
+<p>Value constructors are functions, so we can map them and partially
+apply them and everything. If we want a list of concentric circles with
+different radii, we can do this.</p>
+<pre class="haskell:hs"><code>ghci&gt; map (Circle 10 20) [4,5,6,6]
+[Circle 10.0 20.0 4.0,Circle 10.0 20.0 5.0,Circle 10.0 20.0 6.0,Circle 10.0 20.0 6.0]</code></pre>
+<p>Our data type is good, although it could be better. Let’s make an
+intermediate data type that defines a point in two-dimensional space.
+Then we can use that to make our shapes more understandable.</p>
+<pre class="haskell:hs"><code>data Point = Point Float Float deriving (Show)
+data Shape = Circle Point Float | Rectangle Point Point deriving (Show)</code></pre>
+<p>Notice that when defining a point, we used the same name for the data
+type and the value constructor. This has no special meaning, although
+it’s common to use the same name as the type if there’s only one value
+constructor. So now the <code>Circle</code> has two fields, one is of
+type <code>Point</code> and the other of type <code>Float</code>. This
+makes it easier to understand what’s what. Same goes for the rectangle.
+We have to adjust our <code>surface</code> function to reflect these
+changes.</p>
+<pre class="haskell:hs"><code>surface :: Shape -&gt; Float
 surface (Circle _ r) = pi * r ^ 2
-surface (Rectangle (Point x1 y1) (Point x2 y2)) = (abs $ x2 - x1) * (abs $ y2 - y1)
-</pre>
-<p>The only thing we had to change were the patterns. We disregarded the whole point in the circle pattern. In the rectangle pattern, we just used a nested pattern matching to get the fields of the points. If we wanted to reference the points themselves for some reason, we could have used as-patterns.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; surface (Rectangle (Point 0 0) (Point 100 100))
+surface (Rectangle (Point x1 y1) (Point x2 y2)) = (abs $ x2 - x1) * (abs $ y2 - y1)</code></pre>
+<p>The only thing we had to change were the patterns. We disregarded the
+whole point in the circle pattern. In the rectangle pattern, we just
+used a nested pattern matching to get the fields of the points. If we
+wanted to reference the points themselves for some reason, we could have
+used as-patterns.</p>
+<pre class="haskell:hs"><code>ghci&gt; surface (Rectangle (Point 0 0) (Point 100 100))
 10000.0
 ghci&gt; surface (Circle (Point 0 0) 24)
-1809.5574
-</pre>
-<p>How about a function that nudges a shape? It takes a shape, the amount to move it on the x axis and the amount to move it on the y axis and then returns a new shape that has the same dimensions, only it's located somewhere else.</p>
-<pre name="code" class="haskell:hs">
-nudge :: Shape -&gt; Float -&gt; Float -&gt; Shape
+1809.5574</code></pre>
+<p>How about a function that nudges a shape? It takes a shape, the
+amount to move it on the x axis and the amount to move it on the y axis
+and then returns a new shape that has the same dimensions, only it’s
+located somewhere else.</p>
+<pre class="haskell:hs"><code>nudge :: Shape -&gt; Float -&gt; Float -&gt; Shape
 nudge (Circle (Point x y) r) a b = Circle (Point (x+a) (y+b)) r
-nudge (Rectangle (Point x1 y1) (Point x2 y2)) a b = Rectangle (Point (x1+a) (y1+b)) (Point (x2+a) (y2+b))
-</pre>
-<p>Pretty straightforward. We add the nudge amounts to the points that denote the position of the shape.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; nudge (Circle (Point 34 34) 10) 5 10
-Circle (Point 39.0 44.0) 10.0
-</pre>
-<p>If we don't want to deal directly with points, we can make some auxiliary functions that create shapes of some size at the zero coordinates and then nudge those.</p>
-<pre name="code" class="haskell:hs">
-baseCircle :: Float -&gt; Shape
+nudge (Rectangle (Point x1 y1) (Point x2 y2)) a b = Rectangle (Point (x1+a) (y1+b)) (Point (x2+a) (y2+b))</code></pre>
+<p>Pretty straightforward. We add the nudge amounts to the points that
+denote the position of the shape.</p>
+<pre class="haskell:hs"><code>ghci&gt; nudge (Circle (Point 34 34) 10) 5 10
+Circle (Point 39.0 44.0) 10.0</code></pre>
+<p>If we don’t want to deal directly with points, we can make some
+auxiliary functions that create shapes of some size at the zero
+coordinates and then nudge those.</p>
+<pre class="haskell:hs"><code>baseCircle :: Float -&gt; Shape
 baseCircle r = Circle (Point 0 0) r
 
 baseRect :: Float -&gt; Float -&gt; Shape
-baseRect width height = Rectangle (Point 0 0) (Point width height)
-</pre>
-<pre name="code" class="haskell:hs">
-ghci&gt; nudge (baseRect 40 100) 60 23
-Rectangle (Point 60.0 23.0) (Point 100.0 123.0)
-</pre>
-<p>You can, of course, export your data types in your modules. To do that, just write your type along with the functions you are exporting and then add some parentheses and in them specify the value constructors that you want to export for it, separated by commas. If you want to export all the value constructors for a given type, just write <span class="fixed">..</span>.</p>
-<p>If we wanted to export the functions and types that we defined here in a module, we could start it off like this:</p>
-<pre name="code" class="haskell:hs">
-module Shapes
+baseRect width height = Rectangle (Point 0 0) (Point width height)</code></pre>
+<pre class="haskell:hs"><code>ghci&gt; nudge (baseRect 40 100) 60 23
+Rectangle (Point 60.0 23.0) (Point 100.0 123.0)</code></pre>
+<p>You can, of course, export your data types in your modules. To do
+that, just write your type along with the functions you are exporting
+and then add some parentheses and in them specify the value constructors
+that you want to export for it, separated by commas. If you want to
+export all the value constructors for a given type, just write
+<code>..</code>.</p>
+<p>If we wanted to export the functions and types that we defined here
+in a module, we could start it off like this:</p>
+<pre class="haskell:hs"><code>module Shapes
 ( Point(..)
 , Shape(..)
 , surface
 , nudge
 , baseCircle
 , baseRect
-) where
-</pre>
-<p>By doing <span class="fixed">Shape(..)</span>, we exported all the value constructors for <span class="fixed">Shape</span>, so that means that whoever imports our module can make shapes by using the <span class="fixed">Rectangle</span> and <span class="fixed">Circle</span> value constructors. It's the same as writing <span class="fixed">Shape (Rectangle, Circle)</span>.</p>
-<p>We could also opt not to export any value constructors for <span class="fixed">Shape</span> by just writing <span class="fixed">Shape</span> in the export statement. That way, someone importing our module could only make shapes by using the auxiliary functions <span class="fixed">baseCircle</span> and <span class="fixed">baseRect</span>. <span class="fixed">Data.Map</span> uses that approach. You can't create a map by doing <span class="fixed">Map.Map [(1,2),(3,4)]</span> because it doesn't export that value constructor. However, you can make a mapping by using one of the auxiliary functions like <span class="fixed">Map.fromList</span>. Remember, value constructors are just functions that take the fields as parameters and return a value of some type (like <span class="fixed">Shape</span>) as a result. So when we choose not to export them, we just prevent the person importing our module from using those functions, but if some other functions that are exported return a type, we can use them to make values of our custom data types.</p>
-<p>Not exporting the value constructors of a data types makes them more abstract in such a way that we hide their implementation. Also, whoever uses our module can't pattern match against the value constructors.</p>
-<a name="record-syntax"></a><h2>Record syntax</h2>
-<img src="assets/images/making-our-own-types-and-typeclasses/record.png" alt="record" class="right" width="208" height="97">
-<p>OK, we've been tasked with creating a data type that describes a person. The info that we want to store about that person is: first name, last name, age, height, phone number, and favorite ice-cream flavor. I don't know about you, but that's all I ever want to know about a person. Let's give it a go!</p>
-<pre name="code" class="haskell:hs">
-data Person = Person String String Int Float String String deriving (Show)
-</pre>
-<p>O-kay. The first field is the first name, the second is the last name, the third is the age and so on. Let's make a person.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; let guy = Person "Buddy" "Finklestein" 43 184.2 "526-2928" "Chocolate"
+) where</code></pre>
+<p>By doing <code>Shape(..)</code>, we exported all the value
+constructors for <code>Shape</code>, so that means that whoever imports
+our module can make shapes by using the <code>Rectangle</code> and
+<code>Circle</code> value constructors. It’s the same as writing
+<code>Shape (Rectangle, Circle)</code>.</p>
+<p>We could also opt not to export any value constructors for
+<code>Shape</code> by just writing <code>Shape</code> in the export
+statement. That way, someone importing our module could only make shapes
+by using the auxiliary functions <code>baseCircle</code> and
+<code>baseRect</code>. <code>Data.Map</code> uses that approach. You
+can’t create a map by doing <code>Map.Map [(1,2),(3,4)]</code> because
+it doesn’t export that value constructor. However, you can make a
+mapping by using one of the auxiliary functions like
+<code>Map.fromList</code>. Remember, value constructors are just
+functions that take the fields as parameters and return a value of some
+type (like <code>Shape</code>) as a result. So when we choose not to
+export them, we just prevent the person importing our module from using
+those functions, but if some other functions that are exported return a
+type, we can use them to make values of our custom data types.</p>
+<p>Not exporting the value constructors of a data types makes them more
+abstract in such a way that we hide their implementation. Also, whoever
+uses our module can’t pattern match against the value constructors.</p>
+<h2 id="record-syntax">Record syntax</h2>
+<p><img
+src="assets/images/making-our-own-types-and-typeclasses/record.png"
+class="right" width="208" height="97" alt="record" /></p>
+<p>OK, we’ve been tasked with creating a data type that describes a
+person. The info that we want to store about that person is: first name,
+last name, age, height, phone number, and favorite ice-cream flavor. I
+don’t know about you, but that’s all I ever want to know about a person.
+Let’s give it a go!</p>
+<pre class="haskell:hs"><code>data Person = Person String String Int Float String String deriving (Show)</code></pre>
+<p>O-kay. The first field is the first name, the second is the last
+name, the third is the age and so on. Let’s make a person.</p>
+<pre class="haskell:hs"><code>ghci&gt; let guy = Person &quot;Buddy&quot; &quot;Finklestein&quot; 43 184.2 &quot;526-2928&quot; &quot;Chocolate&quot;
 ghci&gt; guy
-Person "Buddy" "Finklestein" 43 184.2 "526-2928" "Chocolate"
-</pre>
-<p>That's kind of cool, although slightly unreadable. What if we want to create a function to get separate info from a person? A function that gets some person's first name, a function that gets some person's last name, etc. Well, we'd have to define them kind of like this.</p>
-<pre name="code" class="haskell:hs">
-firstName :: Person -&gt; String
+Person &quot;Buddy&quot; &quot;Finklestein&quot; 43 184.2 &quot;526-2928&quot; &quot;Chocolate&quot;</code></pre>
+<p>That’s kind of cool, although slightly unreadable. What if we want to
+create a function to get separate info from a person? A function that
+gets some person’s first name, a function that gets some person’s last
+name, etc. Well, we’d have to define them kind of like this.</p>
+<pre class="haskell:hs"><code>firstName :: Person -&gt; String
 firstName (Person firstname _ _ _ _ _) = firstname
 
 lastName :: Person -&gt; String
@@ -174,131 +250,216 @@ phoneNumber :: Person -&gt; String
 phoneNumber (Person _ _ _ _ number _) = number
 
 flavor :: Person -&gt; String
-flavor (Person _ _ _ _ _ flavor) = flavor
-</pre>
-<p>Whew! I certainly did not enjoy writing that! Despite being very cumbersome and BORING to write, this method works.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; let guy = Person "Buddy" "Finklestein" 43 184.2 "526-2928" "Chocolate"
+flavor (Person _ _ _ _ _ flavor) = flavor</code></pre>
+<p>Whew! I certainly did not enjoy writing that! Despite being very
+cumbersome and BORING to write, this method works.</p>
+<pre class="haskell:hs"><code>ghci&gt; let guy = Person &quot;Buddy&quot; &quot;Finklestein&quot; 43 184.2 &quot;526-2928&quot; &quot;Chocolate&quot;
 ghci&gt; firstName guy
-"Buddy"
+&quot;Buddy&quot;
 ghci&gt; height guy
 184.2
 ghci&gt; flavor guy
-"Chocolate"
-</pre>
-<p>There must be a better way, you say! Well no, there isn't, sorry.</p>
-<p>Just kidding, there is. Hahaha! The makers of Haskell were very smart and anticipated this scenario. They included an alternative way to write data types. Here's how we could achieve the above functionality with record syntax.</p>
-<pre name="code" class="haskell:hs">
-data Person = Person { firstName :: String
+&quot;Chocolate&quot;</code></pre>
+<p>There must be a better way, you say! Well no, there isn’t, sorry.</p>
+<p>Just kidding, there is. Hahaha! The makers of Haskell were very smart
+and anticipated this scenario. They included an alternative way to write
+data types. Here’s how we could achieve the above functionality with
+record syntax.</p>
+<pre class="haskell:hs"><code>data Person = Person { firstName :: String
                      , lastName :: String
                      , age :: Int
                      , height :: Float
                      , phoneNumber :: String
                      , flavor :: String
-                     } deriving (Show) </pre>
-<p>So instead of just naming the field types one after another and separating them with spaces, we use curly brackets. First we write the name of the field, for instance, <span class="fixed">firstName</span> and then we write a double colon <span class="fixed">::</span> (also called Paamayim Nekudotayim, haha) and then we specify the type. The resulting data type is exactly the same. The main benefit of this is that it creates functions that lookup fields in the data type. By using record syntax to create this data type, Haskell automatically made these functions: <span class="fixed">firstName</span>, <span class="fixed">lastName</span>, <span class="fixed">age</span>, <span class="fixed">height</span>, <span class="fixed">phoneNumber</span> and <span class="fixed">flavor</span>.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; :t flavor
+                     } deriving (Show)</code></pre>
+<p>So instead of just naming the field types one after another and
+separating them with spaces, we use curly brackets. First we write the
+name of the field, for instance, <code>firstName</code> and then we
+write a double colon <code>::</code> (also called Paamayim Nekudotayim,
+haha) and then we specify the type. The resulting data type is exactly
+the same. The main benefit of this is that it creates functions that
+lookup fields in the data type. By using record syntax to create this
+data type, Haskell automatically made these functions:
+<code>firstName</code>, <code>lastName</code>, <code>age</code>,
+<code>height</code>, <code>phoneNumber</code> and
+<code>flavor</code>.</p>
+<pre class="haskell:hs"><code>ghci&gt; :t flavor
 flavor :: Person -&gt; String
 ghci&gt; :t firstName
-firstName :: Person -&gt; String
-</pre>
-<p>There's another benefit to using record syntax. When we derive <span class="fixed">Show</span> for the type, it displays it differently if we use record syntax to define and instantiate the type. Say we have a type that represents a car. We want to keep track of the company that made it, the model name and its year of production. Watch.</p>
-<pre name="code" class="haskell:hs">
-data Car = Car String String Int deriving (Show)
-</pre>
-<pre name="code" class="haskell:hs">
-ghci&gt; Car "Ford" "Mustang" 1967
-Car "Ford" "Mustang" 1967
-</pre>
-<p>If we define it using record syntax, we can make a new car like this.</p>
-<pre name="code" class="haskell:hs">
-data Car = Car {company :: String, model :: String, year :: Int} deriving (Show)
-</pre>
-<pre name="code" class="haskell:hs">
-ghci&gt; Car {company="Ford", model="Mustang", year=1967}
-Car {company = "Ford", model = "Mustang", year = 1967}
-</pre>
-<p>When making a new car, we don't have to necessarily put the fields in the proper order, as long as we list all of them. But if we don't use record syntax, we have to specify them in order.</p>
-<p>Use record syntax when a constructor has several fields and it's not obvious which field is which. If we make a 3D vector data type by doing <span class="fixed">data Vector = Vector Int Int Int</span>, it's pretty obvious that the fields are the components of a vector. However, in our <span class="fixed">Person</span> and <span class="fixed">Car</span> types, it wasn't so obvious and we greatly benefited from using record syntax.</p>
-<a name="type-parameters"></a><h2>Type parameters</h2>
-<p>A value constructor can take some values parameters and then produce a new value. For instance, the <span class="fixed">Car</span> constructor takes three values and produces a car value. In a similar manner, <em>type constructors</em> can take types as parameters to produce new types. This might sound a bit too meta at first, but it's not that complicated. If you're familiar with templates in C++, you'll see some parallels. To get a clear picture of what type parameters work like in action, let's take a look at how a type we've already met is implemented.</p>
-<pre name="code" class="haskell:hs">
-data Maybe a = Nothing | Just a
-</pre>
-<img src="assets/images/making-our-own-types-and-typeclasses/yeti.png" alt="yeti" class="left" width="209" height="260">
-<p>The <span class="fixed">a</span> here is the type parameter. And because there's a type parameter involved, we call <span class="fixed">Maybe</span> a type constructor. Depending on what we want this data type to hold when it's not <span class="fixed">Nothing</span>, this type constructor can end up producing a type of <span class="fixed">Maybe Int</span>, <span class="fixed">Maybe Car</span>, <span class="fixed">Maybe String</span>, etc. No value can have a type of just <span class="fixed">Maybe</span>, because that's not a type per se, it's a type constructor. In order for this to be a real type that a value can be part of, it has to have all its type parameters filled up.</p>
-<p>So if we pass <span class="fixed">Char</span> as the type parameter to <span class="fixed">Maybe</span>, we get a type of <span class="fixed">Maybe Char</span>. The value <span class="fixed">Just 'a'</span> has a type of <span class="fixed">Maybe Char</span>, for example.</p>
-<p>You might not know it, but we used a type that has a type parameter before we used <span class="fixed">Maybe</span>. That type is the list type. Although there's some syntactic sugar in play, the list type takes a parameter to produce a concrete type. Values can have an <span class="fixed">[Int]</span> type, a <span class="fixed">[Char]</span> type, a <span class="fixed">[[String]]</span> type, but you can't have a value that just has a type of <span class="fixed">[]</span>.</p>
-<p>Let's play around with the <span class="fixed">Maybe</span> type.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; Just "Haha"
-Just "Haha"
+firstName :: Person -&gt; String</code></pre>
+<p>There’s another benefit to using record syntax. When we derive
+<code>Show</code> for the type, it displays it differently if we use
+record syntax to define and instantiate the type. Say we have a type
+that represents a car. We want to keep track of the company that made
+it, the model name and its year of production. Watch.</p>
+<pre class="haskell:hs"><code>data Car = Car String String Int deriving (Show)</code></pre>
+<pre class="haskell:hs"><code>ghci&gt; Car &quot;Ford&quot; &quot;Mustang&quot; 1967
+Car &quot;Ford&quot; &quot;Mustang&quot; 1967</code></pre>
+<p>If we define it using record syntax, we can make a new car like
+this.</p>
+<pre class="haskell:hs"><code>data Car = Car {company :: String, model :: String, year :: Int} deriving (Show)</code></pre>
+<pre class="haskell:hs"><code>ghci&gt; Car {company=&quot;Ford&quot;, model=&quot;Mustang&quot;, year=1967}
+Car {company = &quot;Ford&quot;, model = &quot;Mustang&quot;, year = 1967}</code></pre>
+<p>When making a new car, we don’t have to necessarily put the fields in
+the proper order, as long as we list all of them. But if we don’t use
+record syntax, we have to specify them in order.</p>
+<p>Use record syntax when a constructor has several fields and it’s not
+obvious which field is which. If we make a 3D vector data type by doing
+<code>data Vector = Vector Int Int Int</code>, it’s pretty obvious that
+the fields are the components of a vector. However, in our
+<code>Person</code> and <code>Car</code> types, it wasn’t so obvious and
+we greatly benefited from using record syntax.</p>
+<h2 id="type-parameters">Type parameters</h2>
+<p>A value constructor can take some values parameters and then produce
+a new value. For instance, the <code>Car</code> constructor takes three
+values and produces a car value. In a similar manner, <strong>type
+constructors</strong> can take types as parameters to produce new types.
+This might sound a bit too meta at first, but it’s not that complicated.
+If you’re familiar with templates in C++, you’ll see some parallels. To
+get a clear picture of what type parameters work like in action, let’s
+take a look at how a type we’ve already met is implemented.</p>
+<pre class="haskell:hs"><code>data Maybe a = Nothing | Just a</code></pre>
+<p><img
+src="assets/images/making-our-own-types-and-typeclasses/yeti.png"
+class="left" width="209" height="260" alt="yeti" /></p>
+<p>The <code>a</code> here is the type parameter. And because there’s a
+type parameter involved, we call <code>Maybe</code> a type constructor.
+Depending on what we want this data type to hold when it’s not
+<code>Nothing</code>, this type constructor can end up producing a type
+of <code>Maybe Int</code>, <code>Maybe Car</code>,
+<code>Maybe String</code>, etc. No value can have a type of just
+<code>Maybe</code>, because that’s not a type per se, it’s a type
+constructor. In order for this to be a real type that a value can be
+part of, it has to have all its type parameters filled up.</p>
+<p>So if we pass <code>Char</code> as the type parameter to
+<code>Maybe</code>, we get a type of <code>Maybe Char</code>. The value
+<code>Just 'a'</code> has a type of <code>Maybe Char</code>, for
+example.</p>
+<p>You might not know it, but we used a type that has a type parameter
+before we used <code>Maybe</code>. That type is the list type. Although
+there’s some syntactic sugar in play, the list type takes a parameter to
+produce a concrete type. Values can have an <code>[Int]</code> type, a
+<code>[Char]</code> type, a <code>[[String]]</code> type, but you can’t
+have a value that just has a type of <code>[]</code>.</p>
+<p>Let’s play around with the <code>Maybe</code> type.</p>
+<pre class="haskell:hs"><code>ghci&gt; Just &quot;Haha&quot;
+Just &quot;Haha&quot;
 ghci&gt; Just 84
 Just 84
-ghci&gt; :t Just "Haha"
-Just "Haha" :: Maybe [Char]
+ghci&gt; :t Just &quot;Haha&quot;
+Just &quot;Haha&quot; :: Maybe [Char]
 ghci&gt; :t Just 84
 Just 84 :: (Num t) =&gt; Maybe t
 ghci&gt; :t Nothing
 Nothing :: Maybe a
 ghci&gt; Just 10 :: Maybe Double
-Just 10.0
-</pre>
-<p>Type parameters are useful because we can make different types with them depending on what kind of types we want contained in our data type. When we do <span class="fixed">:t Just "Haha"</span>, the type inference engine figures it out to be of the type <span class="fixed">Maybe [Char]</span>, because if the <span class="fixed">a</span> in the <span class="fixed">Just a</span> is a string, then the <span class="fixed">a</span> in <span class="fixed">Maybe a</span> must also be a string.</p>
-<p>Notice that the type of <span class="fixed">Nothing</span> is <span class="fixed">Maybe a</span>. Its type is polymorphic. If some function requires a <span class="fixed">Maybe Int</span> as a parameter, we can give it a <span class="fixed">Nothing</span>, because a <span class="fixed">Nothing</span> doesn't contain a value anyway and so it doesn't matter. The <span class="fixed">Maybe a</span> type can act like a <span class="fixed">Maybe Int</span> if it has to, just like <span class="fixed">5</span> can act like an <span class="fixed">Int</span> or a <span class="fixed">Double</span>. Similarly, the type of the empty list is <span class="fixed">[a]</span>. An empty list can act like a list of anything. That's why we can do <span class="fixed">[1,2,3] ++ []</span> and <span class="fixed">["ha","ha","ha"] ++ []</span>.</p>
-<p>Using type parameters is very beneficial, but only when using them makes sense. Usually we use them when our data type would work regardless of the type of the value it then holds inside it, like with our <span class="fixed">Maybe a</span> type. If our type acts as some kind of box, it's good to use them. We could change our <span class="fixed">Car</span> data type from this:</p>
-<pre name="code" class="haskell:hs">
-data Car = Car { company :: String
+Just 10.0</code></pre>
+<p>Type parameters are useful because we can make different types with
+them depending on what kind of types we want contained in our data type.
+When we do <code>:t Just "Haha"</code>, the type inference engine
+figures it out to be of the type <code>Maybe [Char]</code>, because if
+the <code>a</code> in the <code>Just a</code> is a string, then the
+<code>a</code> in <code>Maybe a</code> must also be a string.</p>
+<p>Notice that the type of <code>Nothing</code> is <code>Maybe a</code>.
+Its type is polymorphic. If some function requires a
+<code>Maybe Int</code> as a parameter, we can give it a
+<code>Nothing</code>, because a <code>Nothing</code> doesn’t contain a
+value anyway and so it doesn’t matter. The <code>Maybe a</code> type can
+act like a <code>Maybe Int</code> if it has to, just like <code>5</code>
+can act like an <code>Int</code> or a <code>Double</code>. Similarly,
+the type of the empty list is <code>[a]</code>. An empty list can act
+like a list of anything. That’s why we can do <code>[1,2,3] ++ []</code>
+and <code>["ha","ha","ha"] ++ []</code>.</p>
+<p>Using type parameters is very beneficial, but only when using them
+makes sense. Usually we use them when our data type would work
+regardless of the type of the value it then holds inside it, like with
+our <code>Maybe a</code> type. If our type acts as some kind of box,
+it’s good to use them. We could change our <code>Car</code> data type
+from this:</p>
+<pre class="haskell:hs"><code>data Car = Car { company :: String
                , model :: String
                , year :: Int
-               } deriving (Show)
-</pre>
+               } deriving (Show)</code></pre>
 <p>To this:</p>
-<pre name="code" class="haskell:hs">
-data Car a b c = Car { company :: a
+<pre class="haskell:hs"><code>data Car a b c = Car { company :: a
                      , model :: b
                      , year :: c
-                     } deriving (Show)
-</pre>
-<p>But would we really benefit? The answer is: probably no, because we'd just end up defining functions that only work on the <span class="fixed">Car String String Int</span> type. For instance, given our first definition of <span class="fixed">Car</span>, we could make a function that displays the car's properties in a nice little text.</p>
-<pre name="code" class="haskell:hs">
-tellCar :: Car -&gt; String
-tellCar (Car {company = c, model = m, year = y}) = "This " ++ c ++ " " ++ m ++ " was made in " ++ show y
-</pre>
-<pre name="code" class="haskell:hs">
-ghci&gt; let stang = Car {company="Ford", model="Mustang", year=1967}
+                     } deriving (Show)</code></pre>
+<p>But would we really benefit? The answer is: probably no, because we’d
+just end up defining functions that only work on the
+<code>Car String String Int</code> type. For instance, given our first
+definition of <code>Car</code>, we could make a function that displays
+the car’s properties in a nice little text.</p>
+<pre class="haskell:hs"><code>tellCar :: Car -&gt; String
+tellCar (Car {company = c, model = m, year = y}) = &quot;This &quot; ++ c ++ &quot; &quot; ++ m ++ &quot; was made in &quot; ++ show y</code></pre>
+<pre class="haskell:hs"><code>ghci&gt; let stang = Car {company=&quot;Ford&quot;, model=&quot;Mustang&quot;, year=1967}
 ghci&gt; tellCar stang
-"This Ford Mustang was made in 1967"
-</pre>
-<p>A cute little function! The type declaration is cute and it works nicely. Now what if <span class="fixed">Car</span> was <span class="fixed">Car a b c</span>?</p>
-<pre name="code" class="haskell:hs">
-tellCar :: (Show a) =&gt; Car String String a -&gt; String
-tellCar (Car {company = c, model = m, year = y}) = "This " ++ c ++ " " ++ m ++ " was made in " ++ show y
-</pre>
-<p>We'd have to force this function to take a <span class="fixed">Car</span> type of <span class="fixed">(Show a) =&gt; Car String String a</span>. You can see that the type signature is more complicated and the only benefit we'd actually get would be that we can use any type that's an instance of the <span class="fixed">Show</span> typeclass as the type for <span class="fixed">c</span>.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; tellCar (Car "Ford" "Mustang" 1967)
-"This Ford Mustang was made in 1967"
-ghci&gt; tellCar (Car "Ford" "Mustang" "nineteen sixty seven")
-"This Ford Mustang was made in \"nineteen sixty seven\""
-ghci&gt; :t Car "Ford" "Mustang" 1967
-Car "Ford" "Mustang" 1967 :: (Num t) =&gt; Car [Char] [Char] t
-ghci&gt; :t Car "Ford" "Mustang" "nineteen sixty seven"
-Car "Ford" "Mustang" "nineteen sixty seven" :: Car [Char] [Char] [Char]
-</pre>
-<img src="assets/images/making-our-own-types-and-typeclasses/meekrat.png" alt="meekrat" class="right" width="150" height="267">
-<p>In real life though, we'd end up using <span class="fixed">Car String String Int</span> most of the time and so it would seem that parameterizing the <span class="fixed">Car</span> type isn't really worth it. We usually use type parameters when the type that's contained inside the data type's various value constructors isn't really that important for the type to work. A list of stuff is a list of stuff and it doesn't matter what the type of that stuff is, it can still work. If we want to sum a list of numbers, we can specify later in the summing function that we specifically want a list of numbers. Same goes for <span class="fixed">Maybe</span>. <span class="fixed">Maybe</span> represents an option of either having nothing or having one of something. It doesn't matter what the type of that something is.</p>
-
-<p>Another example of a parameterized type that we've already met is <span class="fixed">Map k v</span> from <span class="fixed">Data.Map</span>. The <span class="fixed">k</span> is the type of the keys in a map and the <span class="fixed">v</span> is the type of the values. This is a good example of where type parameters are very useful. Having maps parameterized enables us to have mappings from any type to any other type, as long as the type of the key is part of the <span class="fixed">Ord</span> typeclass. If we were defining a mapping type, we could add a typeclass constraint in the <i>data</i> declaration:</p>
-<pre name="code" class="haskell:hs">
-data (Ord k) =&gt; Map k v = ...
-</pre>
-<p>However, it's a very strong convention in Haskell to <em>never add typeclass constraints in data declarations. </em>Why? Well, because we don't benefit a lot, but we end up writing more class constraints, even when we don't need them. If we put or don't put the <span class="fixed">Ord k</span> constraint in the <i>data</i> declaration for <span class="fixed">Map k v</span>, we're going to have to put the constraint into functions that assume the keys in a map can be ordered. But if we don't put the constraint in the data declaration, we don't have to put <span class="fixed">(Ord k) =&gt;</span> in the type declarations of functions that don't care whether the keys can be ordered or not. An example of such a function is <span class="fixed">toList</span>, that just takes a mapping and converts it to an associative list. Its type signature is <span class="fixed">toList :: Map k a -&gt; [(k, a)]</span>. If <span class="fixed">Map k v</span> had a type constraint in its <i>data</i> declaration, the type for <span class="fixed">toList</span> would have to be <span class="fixed">toList :: (Ord k) =&gt; Map k a -&gt; [(k, a)]</span>, even though the function doesn't do any comparing of keys by order.</p>
-<p>So don't put type constraints into <i>data</i> declarations even if it seems to make sense, because you'll have to put them into the function type declarations either way.</p>
-<p>Let's implement a 3D vector type and add some operations for it. We'll be using a parameterized type because even though it will usually contain numeric types, it will still support several of them.</p>
-<pre name="code" class="haskell:hs">
-data Vector a = Vector a a a deriving (Show)
+&quot;This Ford Mustang was made in 1967&quot;</code></pre>
+<p>A cute little function! The type declaration is cute and it works
+nicely. Now what if <code>Car</code> was <code>Car a b c</code>?</p>
+<pre class="haskell:hs"><code>tellCar :: (Show a) =&gt; Car String String a -&gt; String
+tellCar (Car {company = c, model = m, year = y}) = &quot;This &quot; ++ c ++ &quot; &quot; ++ m ++ &quot; was made in &quot; ++ show y</code></pre>
+<p>We’d have to force this function to take a <code>Car</code> type of
+<code>(Show a) =&gt; Car String String a</code>. You can see that the
+type signature is more complicated and the only benefit we’d actually
+get would be that we can use any type that’s an instance of the
+<code>Show</code> typeclass as the type for <code>c</code>.</p>
+<pre class="haskell:hs"><code>ghci&gt; tellCar (Car &quot;Ford&quot; &quot;Mustang&quot; 1967)
+&quot;This Ford Mustang was made in 1967&quot;
+ghci&gt; tellCar (Car &quot;Ford&quot; &quot;Mustang&quot; &quot;nineteen sixty seven&quot;)
+&quot;This Ford Mustang was made in \&quot;nineteen sixty seven\&quot;&quot;
+ghci&gt; :t Car &quot;Ford&quot; &quot;Mustang&quot; 1967
+Car &quot;Ford&quot; &quot;Mustang&quot; 1967 :: (Num t) =&gt; Car [Char] [Char] t
+ghci&gt; :t Car &quot;Ford&quot; &quot;Mustang&quot; &quot;nineteen sixty seven&quot;
+Car &quot;Ford&quot; &quot;Mustang&quot; &quot;nineteen sixty seven&quot; :: Car [Char] [Char] [Char]</code></pre>
+<p><img
+src="assets/images/making-our-own-types-and-typeclasses/meekrat.png"
+class="right" width="150" height="267" alt="meekrat" /></p>
+<p>In real life though, we’d end up using
+<code>Car String String Int</code> most of the time and so it would seem
+that parameterizing the <code>Car</code> type isn’t really worth it. We
+usually use type parameters when the type that’s contained inside the
+data type’s various value constructors isn’t really that important for
+the type to work. A list of stuff is a list of stuff and it doesn’t
+matter what the type of that stuff is, it can still work. If we want to
+sum a list of numbers, we can specify later in the summing function that
+we specifically want a list of numbers. Same goes for
+<code>Maybe</code>. <code>Maybe</code> represents an option of either
+having nothing or having one of something. It doesn’t matter what the
+type of that something is.</p>
+<p>Another example of a parameterized type that we’ve already met is
+<code>Map k v</code> from <code>Data.Map</code>. The <code>k</code> is
+the type of the keys in a map and the <code>v</code> is the type of the
+values. This is a good example of where type parameters are very useful.
+Having maps parameterized enables us to have mappings from any type to
+any other type, as long as the type of the key is part of the
+<code>Ord</code> typeclass. If we were defining a mapping type, we could
+add a typeclass constraint in the <em>data</em> declaration:</p>
+<pre class="haskell:hs"><code>data (Ord k) =&gt; Map k v = ...</code></pre>
+<p>However, it’s a very strong convention in Haskell to <strong>never
+add typeclass constraints in data declarations.</strong> Why? Well,
+because we don’t benefit a lot, but we end up writing more class
+constraints, even when we don’t need them. If we put or don’t put the
+<code>Ord k</code> constraint in the <em>data</em> declaration for
+<code>Map k v</code>, we’re going to have to put the constraint into
+functions that assume the keys in a map can be ordered. But if we don’t
+put the constraint in the data declaration, we don’t have to put
+<code>(Ord k) =&gt;</code> in the type declarations of functions that
+don’t care whether the keys can be ordered or not. An example of such a
+function is <code>toList</code>, that just takes a mapping and converts
+it to an associative list. Its type signature is
+<code>toList :: Map k a -&gt; [(k, a)]</code>. If <code>Map k v</code>
+had a type constraint in its <em>data</em> declaration, the type for
+<code>toList</code> would have to be
+<code>toList :: (Ord k) =&gt; Map k a -&gt; [(k, a)]</code>, even though
+the function doesn’t do any comparing of keys by order.</p>
+<p>So don’t put type constraints into <em>data</em> declarations even if
+it seems to make sense, because you’ll have to put them into the
+function type declarations either way.</p>
+<p>Let’s implement a 3D vector type and add some operations for it.
+We’ll be using a parameterized type because even though it will usually
+contain numeric types, it will still support several of them.</p>
+<pre class="haskell:hs"><code>data Vector a = Vector a a a deriving (Show)
 
 vplus :: (Num t) =&gt; Vector t -&gt; Vector t -&gt; Vector t
 (Vector i j k) `vplus` (Vector l m n) = Vector (i+l) (j+m) (k+n)
@@ -307,12 +468,30 @@ vectMult :: (Num t) =&gt; Vector t -&gt; t -&gt; Vector t
 (Vector i j k) `vectMult` m = Vector (i*m) (j*m) (k*m)
 
 scalarMult :: (Num t) =&gt; Vector t -&gt; Vector t -&gt; t
-(Vector i j k) `scalarMult` (Vector l m n) = i*l + j*m + k*n
-</pre>
-<p><span class="fixed">vplus</span> is for adding two vectors together. Two vectors are added just by adding their corresponding components. <span class="fixed">scalarMult</span> is for the scalar product of two vectors and <span class="fixed">vectMult</span> is for multiplying a vector with a scalar. These functions can operate on types of <span class="fixed">Vector Int</span>, <span class="fixed">Vector Integer</span>, <span class="fixed">Vector Float</span>, whatever, as long as the <span class="fixed">a</span> from <span class="fixed">Vector a</span> is from the <span class="fixed">Num</span> typeclass. Also, if you examine the type declaration for these functions, you'll see that they can operate only on vectors of the same type and the numbers involved must also be of the type that is contained in the vectors. Notice that we didn't put a <span class="fixed">Num</span> class constraint in the <i>data</i> declaration, because we'd have to repeat it in the functions anyway.</p>
-<p>Once again, it's very important to distinguish between the type constructor and the value constructor. When declaring a data type, the part before the <span class="fixed">=</span> is the type constructor and the constructors after it (possibly separated by <span class="fixed">|</span>'s) are value constructors. Giving a function a type of <span class="fixed">Vector t t t -&gt; Vector t t t -&gt; t</span> would be wrong, because we have to put types in type declaration and the vector <em>type</em> constructor takes only one parameter, whereas the value constructor takes three. Let's play around with our vectors.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; Vector 3 5 8 `vplus` Vector 9 2 8
+(Vector i j k) `scalarMult` (Vector l m n) = i*l + j*m + k*n</code></pre>
+<p><code>vplus</code> is for adding two vectors together. Two vectors
+are added just by adding their corresponding components.
+<code>scalarMult</code> is for the scalar product of two vectors and
+<code>vectMult</code> is for multiplying a vector with a scalar. These
+functions can operate on types of <code>Vector Int</code>,
+<code>Vector Integer</code>, <code>Vector Float</code>, whatever, as
+long as the <code>a</code> from <code>Vector a</code> is from the
+<code>Num</code> typeclass. Also, if you examine the type declaration
+for these functions, you’ll see that they can operate only on vectors of
+the same type and the numbers involved must also be of the type that is
+contained in the vectors. Notice that we didn’t put a <code>Num</code>
+class constraint in the <em>data</em> declaration, because we’d have to
+repeat it in the functions anyway.</p>
+<p>Once again, it’s very important to distinguish between the type
+constructor and the value constructor. When declaring a data type, the
+part before the <code>=</code> is the type constructor and the
+constructors after it (possibly separated by <code>|</code>’s) are value
+constructors. Giving a function a type of
+<code>Vector t t t -&gt; Vector t t t -&gt; t</code> would be wrong,
+because we have to put types in type declaration and the vector
+<strong>type</strong> constructor takes only one parameter, whereas the
+value constructor takes three. Let’s play around with our vectors.</p>
+<pre class="haskell:hs"><code>ghci&gt; Vector 3 5 8 `vplus` Vector 9 2 8
 Vector 12 7 16
 ghci&gt; Vector 3 5 8 `vplus` Vector 9 2 8 `vplus` Vector 0 2 3
 Vector 12 9 19
@@ -321,350 +500,575 @@ Vector 30 90 70
 ghci&gt; Vector 4 9 5 `scalarMult` Vector 9.0 2.0 4.0
 74.0
 ghci&gt; Vector 2 9 3 `vectMult` (Vector 4 9 5 `scalarMult` Vector 9 2 4)
-Vector 148 666 222
-</pre>
-<a name="derived-instances"></a><h2>Derived instances</h2>
-<img src="assets/images/making-our-own-types-and-typeclasses/gob.png" alt="gob" class="right" width="112" height="350">
-<p>In the <a href="types-and-typeclasses.html#typeclasses-101">Typeclasses 101</a> section, we explained the basics of typeclasses. We explained that a typeclass is a sort of an interface that defines some behavior. A type can be made an <em>instance</em> of a typeclass if it supports that behavior. Example: the <span class="fixed">Int</span> type is an instance of the <span class="fixed">Eq</span> typeclass because the <span class="fixed">Eq</span> typeclass defines behavior for stuff that can be equated. And because integers can be equated, <span class="fixed">Int</span> is a part of the <span class="fixed">Eq</span> typeclass. The real usefulness comes with the functions that act as the interface for <span class="fixed">Eq</span>, namely <span class="fixed">==</span> and <span class="fixed">/=</span>. If a type is a part of the <span class="fixed">Eq</span> typeclass, we can use the <span class="fixed">==</span> functions with values of that type. That's why expressions like <span class="fixed">4 == 4</span> and <span class="fixed">"foo" /= "bar"</span> typecheck.</p>
-<p>We also mentioned that they're often confused with classes in languages like Java, Python, C++ and the like, which then baffles a lot of people. In those languages, classes are a blueprint from which we then create objects that contain state and can do some actions. Typeclasses are more like interfaces. We don't make data from typeclasses. Instead, we first make our data type and then we think about what it can act like. If it can act like something that can be equated, we make it an instance of the <span class="fixed">Eq</span> typeclass. If it can act like something that can be ordered, we make it an instance of the <span class="fixed">Ord</span> typeclass.</p>
-<p>In the next section, we'll take a look at how we can manually make our types instances of typeclasses by implementing the functions defined by the typeclasses. But right now, let's see how Haskell can automatically make our type an instance of any of the following typeclasses: <span class="fixed">Eq</span>, <span class="fixed">Ord</span>, <span class="fixed">Enum</span>, <span class="fixed">Bounded</span>, <span class="fixed">Show</span>, <span class="fixed">Read</span>. Haskell can derive the behavior of our types in these contexts if we use the <i>deriving</i> keyword when making our data type.</p>
+Vector 148 666 222</code></pre>
+<h2 id="derived-instances">Derived instances</h2>
+<p><img src="assets/images/making-our-own-types-and-typeclasses/gob.png"
+class="right" width="112" height="350" alt="gob" /></p>
+<p>In the <a
+href="types-and-typeclasses.html#typeclasses-101">Typeclasses 101</a>
+section, we explained the basics of typeclasses. We explained that a
+typeclass is a sort of an interface that defines some behavior. A type
+can be made an <strong>instance</strong> of a typeclass if it supports
+that behavior. Example: the <code>Int</code> type is an instance of the
+<code>Eq</code> typeclass because the <code>Eq</code> typeclass defines
+behavior for stuff that can be equated. And because integers can be
+equated, <code>Int</code> is a part of the <code>Eq</code> typeclass.
+The real usefulness comes with the functions that act as the interface
+for <code>Eq</code>, namely <code>==</code> and <code>/=</code>. If a
+type is a part of the <code>Eq</code> typeclass, we can use the
+<code>==</code> functions with values of that type. That’s why
+expressions like <code>4 == 4</code> and <code>"foo" /= "bar"</code>
+typecheck.</p>
+<p>We also mentioned that they’re often confused with classes in
+languages like Java, Python, C++ and the like, which then baffles a lot
+of people. In those languages, classes are a blueprint from which we
+then create objects that contain state and can do some actions.
+Typeclasses are more like interfaces. We don’t make data from
+typeclasses. Instead, we first make our data type and then we think
+about what it can act like. If it can act like something that can be
+equated, we make it an instance of the <code>Eq</code> typeclass. If it
+can act like something that can be ordered, we make it an instance of
+the <code>Ord</code> typeclass.</p>
+<p>In the next section, we’ll take a look at how we can manually make
+our types instances of typeclasses by implementing the functions defined
+by the typeclasses. But right now, let’s see how Haskell can
+automatically make our type an instance of any of the following
+typeclasses: <code>Eq</code>, <code>Ord</code>, <code>Enum</code>,
+<code>Bounded</code>, <code>Show</code>, <code>Read</code>. Haskell can
+derive the behavior of our types in these contexts if we use the
+<em>deriving</em> keyword when making our data type.</p>
 <p>Consider this data type:</p>
-<pre name="code" class="haskell:hs">
-data Person = Person { firstName :: String
+<pre class="haskell:hs"><code>data Person = Person { firstName :: String
                      , lastName :: String
                      , age :: Int
-                     }
-</pre>
-<p>It describes a person. Let's assume that no two people have the same combination of first name, last name and age. Now, if we have records for two people, does it make sense to see if they represent the same person? Sure it does. We can try to equate them and see if they're equal or not. That's why it would make sense for this type to be part of the <span class="fixed">Eq</span> typeclass. We'll derive the instance.</p>
-<pre name="code" class="haskell:hs">
-data Person = Person { firstName :: String
+                     }</code></pre>
+<p>It describes a person. Let’s assume that no two people have the same
+combination of first name, last name and age. Now, if we have records
+for two people, does it make sense to see if they represent the same
+person? Sure it does. We can try to equate them and see if they’re equal
+or not. That’s why it would make sense for this type to be part of the
+<code>Eq</code> typeclass. We’ll derive the instance.</p>
+<pre class="haskell:hs"><code>data Person = Person { firstName :: String
                      , lastName :: String
                      , age :: Int
-                     } deriving (Eq)
-</pre>
-<p>When we derive the <span class="fixed">Eq</span> instance for a type and then try to compare two values of that type with <span class="fixed">==</span> or <span class="fixed">/=</span>, Haskell will see if the value constructors match (there's only one value constructor here though) and then it will check if all the data contained inside matches by testing each pair of fields with <span class="fixed">==</span>. There's only one catch though, the types of all the fields also have to be part of the <span class="fixed">Eq</span> typeclass. But since both <span class="fixed">String</span> and <span class="fixed">Int</span> are, we're OK. Let's test our <span class="fixed">Eq</span> instance.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; let mikeD = Person {firstName = "Michael", lastName = "Diamond", age = 43}
-ghci&gt; let adRock = Person {firstName = "Adam", lastName = "Horovitz", age = 41}
-ghci&gt; let mca = Person {firstName = "Adam", lastName = "Yauch", age = 44}
+                     } deriving (Eq)</code></pre>
+<p>When we derive the <code>Eq</code> instance for a type and then try
+to compare two values of that type with <code>==</code> or
+<code>/=</code>, Haskell will see if the value constructors match
+(there’s only one value constructor here though) and then it will check
+if all the data contained inside matches by testing each pair of fields
+with <code>==</code>. There’s only one catch though, the types of all
+the fields also have to be part of the <code>Eq</code> typeclass. But
+since both <code>String</code> and <code>Int</code> are, we’re OK. Let’s
+test our <code>Eq</code> instance.</p>
+<pre class="haskell:hs"><code>ghci&gt; let mikeD = Person {firstName = &quot;Michael&quot;, lastName = &quot;Diamond&quot;, age = 43}
+ghci&gt; let adRock = Person {firstName = &quot;Adam&quot;, lastName = &quot;Horovitz&quot;, age = 41}
+ghci&gt; let mca = Person {firstName = &quot;Adam&quot;, lastName = &quot;Yauch&quot;, age = 44}
 ghci&gt; mca == adRock
 False
 ghci&gt; mikeD == adRock
 False
 ghci&gt; mikeD == mikeD
 True
-ghci&gt; mikeD == Person {firstName = "Michael", lastName = "Diamond", age = 43}
-True
-</pre>
-<p>Of course, since <span class="fixed">Person</span> is now in <span class="fixed">Eq</span>, we can use it as the <span class="fixed">a</span> for all functions that have a class constraint of <span class="fixed">Eq a</span> in their type signature, such as <span class="fixed">elem</span>.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; let beastieBoys = [mca, adRock, mikeD]
+ghci&gt; mikeD == Person {firstName = &quot;Michael&quot;, lastName = &quot;Diamond&quot;, age = 43}
+True</code></pre>
+<p>Of course, since <code>Person</code> is now in <code>Eq</code>, we
+can use it as the <code>a</code> for all functions that have a class
+constraint of <code>Eq a</code> in their type signature, such as
+<code>elem</code>.</p>
+<pre class="haskell:hs"><code>ghci&gt; let beastieBoys = [mca, adRock, mikeD]
 ghci&gt; mikeD `elem` beastieBoys
-True
-</pre>
-<p>The <span class="fixed">Show</span> and <span class="fixed">Read</span> typeclasses are for things that can be converted to or from strings, respectively. Like with <span class="fixed">Eq</span>, if a type's constructors have fields, their type has to be a part of <span class="fixed">Show</span> or <span class="fixed">Read</span> if we want to make our type an instance of them. Let's make our <span class="fixed">Person</span> data type a part of <span class="fixed">Show</span> and <span class="fixed">Read</span> as well.</p>
-<pre name="code" class="haskell:hs">
-data Person = Person { firstName :: String
+True</code></pre>
+<p>The <code>Show</code> and <code>Read</code> typeclasses are for
+things that can be converted to or from strings, respectively. Like with
+<code>Eq</code>, if a type’s constructors have fields, their type has to
+be a part of <code>Show</code> or <code>Read</code> if we want to make
+our type an instance of them. Let’s make our <code>Person</code> data
+type a part of <code>Show</code> and <code>Read</code> as well.</p>
+<pre class="haskell:hs"><code>data Person = Person { firstName :: String
                      , lastName :: String
                      , age :: Int
-                     } deriving (Eq, Show, Read)
-</pre>
+                     } deriving (Eq, Show, Read)</code></pre>
 <p>Now we can print a person out to the terminal.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; let mikeD = Person {firstName = "Michael", lastName = "Diamond", age = 43}
+<pre class="haskell:hs"><code>ghci&gt; let mikeD = Person {firstName = &quot;Michael&quot;, lastName = &quot;Diamond&quot;, age = 43}
 ghci&gt; mikeD
-Person {firstName = "Michael", lastName = "Diamond", age = 43}
-ghci&gt; "mikeD is: " ++ show mikeD
-"mikeD is: Person {firstName = \"Michael\", lastName = \"Diamond\", age = 43}"
-</pre>
-<p>Had we tried to print a person on the terminal before making the <span class="fixed">Person</span> data type part of <span class="fixed">Show</span>, Haskell would have complained at us, claiming it doesn't know how to represent a person as a string. But now that we've derived a <span class="fixed">Show</span> instance for it, it does know.</p>
-<p><span class="fixed">Read</span> is pretty much the inverse typeclass of <span class="fixed">Show</span>. <span class="fixed">Show</span> is for converting values of our a type to a string, <span class="fixed">Read</span> is for converting strings to values of our type. Remember though, when we use the <span class="fixed">read</span> function, we have to use an explicit type annotation to tell Haskell which type we want to get as a result. If we don't make the type we want as a result explicit, Haskell doesn't know which type we want.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; read "Person {firstName =\"Michael\", lastName =\"Diamond\", age = 43}" :: Person
-Person {firstName = "Michael", lastName = "Diamond", age = 43}
-</pre>
-<p>If we use the result of our <span class="fixed">read</span> later on in a way that Haskell can infer that it should read it as a person, we don't have to use type annotation.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; read "Person {firstName =\"Michael\", lastName =\"Diamond\", age = 43}" == mikeD
-True
-</pre>
-<p>We can also read parameterized types, but we have to fill in the type parameters. So we can't do <span class="fixed">read "Just 't'" :: Maybe a</span>, but we can do <span class="fixed">read "Just 't'" :: Maybe Char</span>.</p>
-<p>We can derive instances for the <span class="fixed">Ord</span> type class,
-which is for types that have values that can be ordered. If we compare two
-values of the same type that were made using different constructors, the value
-which was made with a constructor that's defined first is considered smaller.
-For instance, consider the <span class="fixed">Bool</span>
-type, which can have a value of either <span class="fixed">False</span> or <span
-class="fixed">True</span>. For the purpose of seeing how it behaves when
-compared, we can think of it as being implemented like
-this:</p>
-<pre name="code" class="haskell:hs">
-data Bool = False | True deriving (Ord)
-</pre>
-<p>Because the <span class="fixed">False</span> value constructor is specified first and the <span class="fixed">True</span> value constructor is specified after it, we can consider <span class="fixed">True</span> as greater than <span class="fixed">False</span>.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; True `compare` False
+Person {firstName = &quot;Michael&quot;, lastName = &quot;Diamond&quot;, age = 43}
+ghci&gt; &quot;mikeD is: &quot; ++ show mikeD
+&quot;mikeD is: Person {firstName = \&quot;Michael\&quot;, lastName = \&quot;Diamond\&quot;, age = 43}&quot;</code></pre>
+<p>Had we tried to print a person on the terminal before making the
+<code>Person</code> data type part of <code>Show</code>, Haskell would
+have complained at us, claiming it doesn’t know how to represent a
+person as a string. But now that we’ve derived a <code>Show</code>
+instance for it, it does know.</p>
+<p><code>Read</code> is pretty much the inverse typeclass of
+<code>Show</code>. <code>Show</code> is for converting values of our a
+type to a string, <code>Read</code> is for converting strings to values
+of our type. Remember though, when we use the <code>read</code>
+function, we have to use an explicit type annotation to tell Haskell
+which type we want to get as a result. If we don’t make the type we want
+as a result explicit, Haskell doesn’t know which type we want.</p>
+<pre class="haskell:hs"><code>ghci&gt; read &quot;Person {firstName =\&quot;Michael\&quot;, lastName =\&quot;Diamond\&quot;, age = 43}&quot; :: Person
+Person {firstName = &quot;Michael&quot;, lastName = &quot;Diamond&quot;, age = 43}</code></pre>
+<p>If we use the result of our <code>read</code> later on in a way that
+Haskell can infer that it should read it as a person, we don’t have to
+use type annotation.</p>
+<pre class="haskell:hs"><code>ghci&gt; read &quot;Person {firstName =\&quot;Michael\&quot;, lastName =\&quot;Diamond\&quot;, age = 43}&quot; == mikeD
+True</code></pre>
+<p>We can also read parameterized types, but we have to fill in the type
+parameters. So we can’t do <code>read "Just 't'" :: Maybe a</code>, but
+we can do <code>read "Just 't'" :: Maybe Char</code>.</p>
+<p>We can derive instances for the <code>Ord</code> type class, which is
+for types that have values that can be ordered. If we compare two values
+of the same type that were made using different constructors, the value
+which was made with a constructor that’s defined first is considered
+smaller. For instance, consider the <code>Bool</code> type, which can
+have a value of either <code>False</code> or <code>True</code>. For the
+purpose of seeing how it behaves when compared, we can think of it as
+being implemented like this:</p>
+<pre class="haskell:hs"><code>data Bool = False | True deriving (Ord)</code></pre>
+<p>Because the <code>False</code> value constructor is specified first
+and the <code>True</code> value constructor is specified after it, we
+can consider <code>True</code> as greater than <code>False</code>.</p>
+<pre class="haskell:hs"><code>ghci&gt; True `compare` False
 GT
 ghci&gt; True &gt; False
 True
 ghci&gt; True &lt; False
-False
-</pre>
-<p>In the <span class="fixed">Maybe a</span> data type, the <span class="fixed">Nothing</span> value constructor is specified before the <span class="fixed">Just</span> value constructor, so a value of <span class="fixed">Nothing</span> is always smaller than a value of <span class="fixed">Just something</span>, even if that something is minus one billion trillion. But if we compare two <span class="fixed">Just</span> values, then it goes to compare what's inside them.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; Nothing &lt; Just 100
+False</code></pre>
+<p>In the <code>Maybe a</code> data type, the <code>Nothing</code> value
+constructor is specified before the <code>Just</code> value constructor,
+so a value of <code>Nothing</code> is always smaller than a value of
+<code>Just something</code>, even if that something is minus one billion
+trillion. But if we compare two <code>Just</code> values, then it goes
+to compare what’s inside them.</p>
+<pre class="haskell:hs"><code>ghci&gt; Nothing &lt; Just 100
 True
 ghci&gt; Nothing &gt; Just (-49999)
 False
 ghci&gt; Just 3 `compare` Just 2
 GT
 ghci&gt; Just 100 &gt; Just 50
-True
-</pre>
-<p>But we can't do something like <span class="fixed">Just (*3) > Just (*2)</span>, because <span class="fixed">(*3)</span> and <span class="fixed">(*2)</span> are functions, which aren't instances of <span class="fixed">Ord</span>.</p>
-<p>We can easily use algebraic data types to make enumerations and the <span class="fixed">Enum</span> and <span class="fixed">Bounded</span> typeclasses help us with that. Consider the following data type:</p>
-<pre name="code" class="haskell:hs">
-data Day = Monday | Tuesday | Wednesday | Thursday | Friday | Saturday | Sunday
-</pre>
-<p>Because all the value constructors are nullary (take no parameters, i.e. fields), we can make it part of the <span class="fixed">Enum</span> typeclass. The <span class="fixed">Enum</span> typeclass is for things that have predecessors and successors. We can also make it part of the <span class="fixed">Bounded</span> typeclass, which is for things that have a lowest possible value and highest possible value. And while we're at it, let's also make it an instance of all the other derivable typeclasses and see what we can do with it.</p>
-<pre name="code" class="haskell:hs">
-data Day = Monday | Tuesday | Wednesday | Thursday | Friday | Saturday | Sunday
-           deriving (Eq, Ord, Show, Read, Bounded, Enum)
-</pre>
-<p>Because it's part of the <span class="fixed">Show</span> and <span class="fixed">Read</span> typeclasses, we can convert values of this type to and from strings.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; Wednesday
+True</code></pre>
+<p>But we can’t do something like <code>Just (*3) &gt; Just (*2)</code>,
+because <code>(*3)</code> and <code>(*2)</code> are functions, which
+aren’t instances of <code>Ord</code>.</p>
+<p>We can easily use algebraic data types to make enumerations and the
+<code>Enum</code> and <code>Bounded</code> typeclasses help us with
+that. Consider the following data type:</p>
+<pre class="haskell:hs"><code>data Day = Monday | Tuesday | Wednesday | Thursday | Friday | Saturday | Sunday</code></pre>
+<p>Because all the value constructors are nullary (take no parameters,
+i.e. fields), we can make it part of the <code>Enum</code> typeclass.
+The <code>Enum</code> typeclass is for things that have predecessors and
+successors. We can also make it part of the <code>Bounded</code>
+typeclass, which is for things that have a lowest possible value and
+highest possible value. And while we’re at it, let’s also make it an
+instance of all the other derivable typeclasses and see what we can do
+with it.</p>
+<pre class="haskell:hs"><code>data Day = Monday | Tuesday | Wednesday | Thursday | Friday | Saturday | Sunday
+           deriving (Eq, Ord, Show, Read, Bounded, Enum)</code></pre>
+<p>Because it’s part of the <code>Show</code> and <code>Read</code>
+typeclasses, we can convert values of this type to and from strings.</p>
+<pre class="haskell:hs"><code>ghci&gt; Wednesday
 Wednesday
 ghci&gt; show Wednesday
-"Wednesday"
-ghci&gt; read "Saturday" :: Day
-Saturday
-</pre>
-<p>Because it's part of the <span class="fixed">Eq</span> and <span class="fixed">Ord</span> typeclasses, we can compare or equate days.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; Saturday == Sunday
+&quot;Wednesday&quot;
+ghci&gt; read &quot;Saturday&quot; :: Day
+Saturday</code></pre>
+<p>Because it’s part of the <code>Eq</code> and <code>Ord</code>
+typeclasses, we can compare or equate days.</p>
+<pre class="haskell:hs"><code>ghci&gt; Saturday == Sunday
 False
 ghci&gt; Saturday == Saturday
 True
 ghci&gt; Saturday &gt; Friday
 True
 ghci&gt; Monday `compare` Wednesday
-LT
-</pre>
-<p>It's also part of <span class="fixed">Bounded</span>, so we can get the lowest and highest day.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; minBound :: Day
+LT</code></pre>
+<p>It’s also part of <code>Bounded</code>, so we can get the lowest and
+highest day.</p>
+<pre class="haskell:hs"><code>ghci&gt; minBound :: Day
 Monday
 ghci&gt; maxBound :: Day
-Sunday
-</pre>
-<p>It's also an instance of <span class="fixed">Enum</span>. We can get predecessors and successors of days and we can make list ranges from them!</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; succ Monday
+Sunday</code></pre>
+<p>It’s also an instance of <code>Enum</code>. We can get predecessors
+and successors of days and we can make list ranges from them!</p>
+<pre class="haskell:hs"><code>ghci&gt; succ Monday
 Tuesday
 ghci&gt; pred Saturday
 Friday
 ghci&gt; [Thursday .. Sunday]
 [Thursday,Friday,Saturday,Sunday]
 ghci&gt; [minBound .. maxBound] :: [Day]
-[Monday,Tuesday,Wednesday,Thursday,Friday,Saturday,Sunday]
-</pre>
-<p>That's pretty awesome.</p>
-<a name="type-synonyms"></a><h2>Type synonyms</h2>
-<p>
- Previously, we mentioned that when writing types, the <span class="fixed">[Char]</span> and <span class="fixed">String</span> types are equivalent and interchangeable. That's implemented with <em>type synonyms</em>. Type synonyms don't really do anything per se, they're just about giving some types different names so that they make more sense to someone reading our code and documentation. Here's how the standard library defines <span class="fixed">String</span> as a synonym for <span class="fixed">[Char]</span>.
- </p>
- <pre name="code" class="haskell:hs">
- type String = [Char]
- </pre>
- <img src="assets/images/making-our-own-types-and-typeclasses/chicken.png" alt="chicken" class="left" width="169" height="225">
- <p>
- We've introduced the <i>type</i> keyword. The keyword might be misleading to some, because we're not actually making anything new (we did that with the <i>data</i> keyword), but we're just making a synonym for an already existing type.
- </p>
- <p>If we make a function that converts a string to uppercase and call it <span class="fixed">toUpperString</span> or something, we can give it a type declaration of <span class="fixed">toUpperString :: [Char] -&gt; [Char]</span> or <span class="fixed">toUpperString :: String -&gt; String</span>. Both of these are essentially the same, only the latter is nicer to read.</p>
- <p>
- When we were dealing with the <span class="fixed">Data.Map</span> module, we first represented a phonebook with an association list before converting it into a map. As we've already found out, an association list is a list of key-value pairs. Let's look at a phonebook that we had.
- </p>
-<pre name="code" class="haskell:hs">
-phoneBook :: [(String,String)]
+[Monday,Tuesday,Wednesday,Thursday,Friday,Saturday,Sunday]</code></pre>
+<p>That’s pretty awesome.</p>
+<h2 id="type-synonyms">Type synonyms</h2>
+<p>Previously, we mentioned that when writing types, the
+<code>[Char]</code> and <code>String</code> types are equivalent and
+interchangeable. That’s implemented with <strong>type synonyms</strong>.
+Type synonyms don’t really do anything per se, they’re just about giving
+some types different names so that they make more sense to someone
+reading our code and documentation. Here’s how the standard library
+defines <code>String</code> as a synonym for <code>[Char]</code>.</p>
+<pre class="haskell:hs"><code>type String = [Char]</code></pre>
+<p><img
+src="assets/images/making-our-own-types-and-typeclasses/chicken.png"
+class="left" width="169" height="225" alt="chicken" /></p>
+<p>We’ve introduced the <em>type</em> keyword. The keyword might be
+misleading to some, because we’re not actually making anything new (we
+did that with the <em>data</em> keyword), but we’re just making a
+synonym for an already existing type.</p>
+<p>If we make a function that converts a string to uppercase and call it
+<code>toUpperString</code> or something, we can give it a type
+declaration of <code>toUpperString :: [Char] -&gt; [Char]</code> or
+<code>toUpperString :: String -&gt; String</code>. Both of these are
+essentially the same, only the latter is nicer to read.</p>
+<p>When we were dealing with the <code>Data.Map</code> module, we first
+represented a phonebook with an association list before converting it
+into a map. As we’ve already found out, an association list is a list of
+key-value pairs. Let’s look at a phonebook that we had.</p>
+<pre class="haskell:hs"><code>phoneBook :: [(String,String)]
 phoneBook =
-    [("amelia","555-2938")
-    ,("freya","452-2928")
-    ,("isabella","493-2928")
-    ,("neil","205-2928")
-    ,("roald","939-8282")
-    ,("tenzing","853-2492")
-    ]</pre>
- <p>We see that the type of <span class="fixed">phoneBook</span> is <span class="fixed">[(String,String)]</span>. That tells us that it's an association list that maps from strings to strings, but not much else. Let's make a type synonym to convey some more information in the type declaration.</p>
-<pre name="code" class="haskell:hs">
-type PhoneBook = [(String,String)]
-</pre>
-<p>Now the type declaration for our phonebook can be <span class="fixed">phoneBook :: PhoneBook</span>. Let's make a type synonym for <span class="fixed">String</span> as well.</p>
-<pre name="code" class="haskell:hs">
-type PhoneNumber = String
+    [(&quot;amelia&quot;,&quot;555-2938&quot;)
+    ,(&quot;freya&quot;,&quot;452-2928&quot;)
+    ,(&quot;isabella&quot;,&quot;493-2928&quot;)
+    ,(&quot;neil&quot;,&quot;205-2928&quot;)
+    ,(&quot;roald&quot;,&quot;939-8282&quot;)
+    ,(&quot;tenzing&quot;,&quot;853-2492&quot;)
+    ]</code></pre>
+<p>We see that the type of <code>phoneBook</code> is
+<code>[(String,String)]</code>. That tells us that it’s an association
+list that maps from strings to strings, but not much else. Let’s make a
+type synonym to convey some more information in the type
+declaration.</p>
+<pre class="haskell:hs"><code>type PhoneBook = [(String,String)]</code></pre>
+<p>Now the type declaration for our phonebook can be
+<code>phoneBook :: PhoneBook</code>. Let’s make a type synonym for
+<code>String</code> as well.</p>
+<pre class="haskell:hs"><code>type PhoneNumber = String
 type Name = String
-type PhoneBook = [(Name,PhoneNumber)]
-</pre>
-<p>Giving the <span class="fixed">String</span> type synonyms is something that Haskell programmers do when they want to convey more information about what strings in their functions should be used as and what they represent.</p>
-<p>So now, when we implement a function that takes a name and a number and sees if that name and number combination is in our phonebook, we can give it a very pretty and descriptive type declaration.</p>
-<pre name="code" class="haskell:hs">
-inPhoneBook :: Name -&gt; PhoneNumber -&gt; PhoneBook -&gt; Bool
-inPhoneBook name pnumber pbook = (name,pnumber) `elem` pbook
-</pre>
-<p>If we decided not to use type synonyms, our function would have a type of <span class="fixed">String -&gt; String -&gt; [(String,String)] -&gt; Bool</span>. In this case, the type declaration that took advantage of type synonyms is easier to understand. However, you shouldn't go overboard with them. We introduce type synonyms either to describe what some existing type represents in our functions (and thus our type declarations become better documentation) or when something has a long-ish type that's repeated a lot (like <span class="fixed">[(String,String)]</span>) but represents something more specific in the context of our functions.</p>
-<p>Type synonyms can also be parameterized. If we want a type that represents an association list type but still want it to be general so it can use any type as the keys and values, we can do this:</p>
-<pre name="code" class="haskell:hs">
-type AssocList k v = [(k,v)]
-</pre>
-<p>Now, a function that gets the value by a key in an association list can have a type of <span class="fixed">(Eq k) =&gt; k -&gt; AssocList k v -&gt; Maybe v</span>. <span class="fixed">AssocList</span> is a type constructor that takes two types and produces a concrete type, like <span class="fixed">AssocList Int String</span>, for instance.</p>
-<div class="hintbox"><em>Fonzie says:</em> Aaay! When I talk about <i>concrete types</i> I mean like fully applied types like <span class="fixed">Map Int String</span> or if we're dealin' with one of them polymorphic functions, <span class="fixed">[a]</span> or <span class="fixed">(Ord a) =&gt; Maybe a</span> and stuff. And like, sometimes me and my buddies say that <span class="fixed">Maybe</span> is a type, but we don't mean that, cause every idiot knows <span class="fixed">Maybe</span> is a type constructor. When I apply an extra type to <span class="fixed">Maybe</span>, like <span class="fixed">Maybe String</span>, then I have a concrete type. You know, values can only have types that are concrete types! So in conclusion, live fast, love hard and don't let anybody else use your comb!</div>
-<p>Just like we can partially apply functions to get new functions, we can partially apply type parameters and get new type constructors from them. Just like we call a function with too few parameters to get back a new function, we can specify a type constructor with too few type parameters and get back a partially applied type constructor. If we wanted a type that represents a map (from <span class="fixed">Data.Map</span>) from integers to something, we could either do this:</p>
-<pre name="code" class="haskell:hs">
-type IntMap v = Map Int v
-</pre>
+type PhoneBook = [(Name,PhoneNumber)]</code></pre>
+<p>Giving the <code>String</code> type synonyms is something that
+Haskell programmers do when they want to convey more information about
+what strings in their functions should be used as and what they
+represent.</p>
+<p>So now, when we implement a function that takes a name and a number
+and sees if that name and number combination is in our phonebook, we can
+give it a very pretty and descriptive type declaration.</p>
+<pre class="haskell:hs"><code>inPhoneBook :: Name -&gt; PhoneNumber -&gt; PhoneBook -&gt; Bool
+inPhoneBook name pnumber pbook = (name,pnumber) `elem` pbook</code></pre>
+<p>If we decided not to use type synonyms, our function would have a
+type of
+<code>String -&gt; String -&gt; [(String,String)] -&gt; Bool</code>. In
+this case, the type declaration that took advantage of type synonyms is
+easier to understand. However, you shouldn’t go overboard with them. We
+introduce type synonyms either to describe what some existing type
+represents in our functions (and thus our type declarations become
+better documentation) or when something has a long-ish type that’s
+repeated a lot (like <code>[(String,String)]</code>) but represents
+something more specific in the context of our functions.</p>
+<p>Type synonyms can also be parameterized. If we want a type that
+represents an association list type but still want it to be general so
+it can use any type as the keys and values, we can do this:</p>
+<pre class="haskell:hs"><code>type AssocList k v = [(k,v)]</code></pre>
+<p>Now, a function that gets the value by a key in an association list
+can have a type of
+<code>(Eq k) =&gt; k -&gt; AssocList k v -&gt; Maybe v</code>.
+<code>AssocList</code> is a type constructor that takes two types and
+produces a concrete type, like <code>AssocList Int String</code>, for
+instance.</p>
+<div class="hintbox">
+<p><strong>Fonzie says:</strong> Aaay! When I talk about <em>concrete
+types</em> I mean like fully applied types like
+<code>Map Int String</code> or if we’re dealin’ with one of them
+polymorphic functions, <code>[a]</code> or
+<code>(Ord a) =&gt; Maybe a</code> and stuff. And like, sometimes me and
+my buddies say that <code>Maybe</code> is a type, but we don’t mean
+that, cause every idiot knows <code>Maybe</code> is a type constructor.
+When I apply an extra type to <code>Maybe</code>, like
+<code>Maybe String</code>, then I have a concrete type. You know, values
+can only have types that are concrete types! So in conclusion, live
+fast, love hard and don’t let anybody else use your comb!</p>
+</div>
+<p>Just like we can partially apply functions to get new functions, we
+can partially apply type parameters and get new type constructors from
+them. Just like we call a function with too few parameters to get back a
+new function, we can specify a type constructor with too few type
+parameters and get back a partially applied type constructor. If we
+wanted a type that represents a map (from <code>Data.Map</code>) from
+integers to something, we could either do this:</p>
+<pre class="haskell:hs"><code>type IntMap v = Map Int v</code></pre>
 <p>Or we could do it like this:</p>
-<pre name="code" class="haskell:hs">
-type IntMap = Map Int
-</pre>
-<p>Either way, the <span class="fixed">IntMap</span> type constructor takes one parameter and that is the type of what the integers will point to.</p>
-<div class="hintbox"><em>Oh yeah</em>. If you're going to try and implement this, you'll probably going to do a qualified import of <span class="fixed">Data.Map</span>. When you do a qualified import, type constructors also have to be preceded with a module name. So you'd write <span class="fixed">type IntMap = Map.Map Int</span>.</div>
-<p>Make sure that you really understand the distinction between type constructors and value constructors. Just because we made a type synonym called <span class="fixed">IntMap</span> or <span class="fixed">AssocList</span> doesn't mean that we can do stuff like <span class="fixed">AssocList [(1,2),(4,5),(7,9)]</span>. All it means is that we can refer to its type by using different names. We can do <span class="fixed">[(1,2),(3,5),(8,9)] :: AssocList Int Int</span>, which will make the numbers inside assume a type of <span class="fixed">Int</span>, but we can still use that list as we would any normal list that has pairs of integers inside. Type synonyms (and types generally) can only be used in the type portion of Haskell. We're in Haskell's type portion whenever we're defining new types (so in <i>data</i> and <i>type</i> declarations) or when we're located after a <span class="fixed">::</span>. The <span class="fixed">::</span> is in type declarations or in type annotations.</p>
-<p>Another cool data type that takes two types as its parameters is the <span class="fixed">Either a b</span> type. This is roughly how it's defined:</p>
-<pre name="code" class="haskell:hs">
-data Either a b = Left a | Right b deriving (Eq, Ord, Read, Show)
-</pre>
-<p>It has two value constructors. If the <span class="fixed">Left</span> is used, then its contents are of type <span class="fixed">a</span> and if <span class="fixed">Right</span> is used, then its contents are of type <span class="fixed">b</span>. So we can use this type to encapsulate a value of one type or another and then when we get a value of type <span class="fixed">Either a b</span>, we usually pattern match on both <span class="fixed">Left</span> and <span class="fixed">Right</span> and we different stuff based on which one of them it was. </p>
-<pre name="code" class="haskell:hs">
-ghci&gt; Right 20
+<pre class="haskell:hs"><code>type IntMap = Map Int</code></pre>
+<p>Either way, the <code>IntMap</code> type constructor takes one
+parameter and that is the type of what the integers will point to.</p>
+<div class="hintbox">
+<p><strong>Oh yeah</strong>. If you’re going to try and implement this,
+you’ll probably going to do a qualified import of <code>Data.Map</code>.
+When you do a qualified import, type constructors also have to be
+preceded with a module name. So you’d write
+<code>type IntMap = Map.Map Int</code>.</p>
+</div>
+<p>Make sure that you really understand the distinction between type
+constructors and value constructors. Just because we made a type synonym
+called <code>IntMap</code> or <code>AssocList</code> doesn’t mean that
+we can do stuff like <code>AssocList [(1,2),(4,5),(7,9)]</code>. All it
+means is that we can refer to its type by using different names. We can
+do <code>[(1,2),(3,5),(8,9)] :: AssocList Int Int</code>, which will
+make the numbers inside assume a type of <code>Int</code>, but we can
+still use that list as we would any normal list that has pairs of
+integers inside. Type synonyms (and types generally) can only be used in
+the type portion of Haskell. We’re in Haskell’s type portion whenever
+we’re defining new types (so in <em>data</em> and <em>type</em>
+declarations) or when we’re located after a <code>::</code>. The
+<code>::</code> is in type declarations or in type annotations.</p>
+<p>Another cool data type that takes two types as its parameters is the
+<code>Either a b</code> type. This is roughly how it’s defined:</p>
+<pre class="haskell:hs"><code>data Either a b = Left a | Right b deriving (Eq, Ord, Read, Show)</code></pre>
+<p>It has two value constructors. If the <code>Left</code> is used, then
+its contents are of type <code>a</code> and if <code>Right</code> is
+used, then its contents are of type <code>b</code>. So we can use this
+type to encapsulate a value of one type or another and then when we get
+a value of type <code>Either a b</code>, we usually pattern match on
+both <code>Left</code> and <code>Right</code> and we different stuff
+based on which one of them it was.</p>
+<pre class="haskell:hs"><code>ghci&gt; Right 20
 Right 20
-ghci&gt; Left "w00t"
-Left "w00t"
-ghci&gt; :t Right 'a'
-Right 'a' :: Either a Char
+ghci&gt; Left &quot;w00t&quot;
+Left &quot;w00t&quot;
+ghci&gt; :t Right &#39;a&#39;
+Right &#39;a&#39; :: Either a Char
 ghci&gt; :t Left True
-Left True :: Either Bool b
-</pre>
-<p>So far, we've seen that <span class="fixed">Maybe a</span> was mostly used to represent the results of computations that could have either failed or not. But sometimes, <span class="fixed">Maybe a</span> isn't good enough because <span class="fixed">Nothing</span> doesn't really convey much information other than that something has failed. That's cool for functions that can fail in only one way or if we're just not interested in how and why they failed. A <span class="fixed">Data.Map</span> lookup fails only if the key we were looking for wasn't in the map, so we know exactly what happened. However, when we're interested in how some function failed or why, we usually use the result type of <span class="fixed">Either a b</span>, where <span class="fixed">a</span> is some sort of type that can tell us something about the possible failure and <span class="fixed">b</span> is the type of a successful computation. Hence, errors use the <span class="fixed">Left</span> value constructor while results use <span class="fixed">Right</span>.</p>
-<p>An example: a high-school has lockers so that students have some place to put their Guns'n'Roses posters. Each locker has a code combination. When a student wants a new locker, they tell the locker supervisor which locker number they want and he gives them the code. However, if someone is already using that locker, he can't tell them the code for the locker and they have to pick a different one. We'll use a map from <span class="fixed">Data.Map</span> to represent the lockers. It'll map from locker numbers to a pair of whether the locker is in use or not and the locker code.</p>
-<pre name="code" class="haskell:hs">
-import qualified Data.Map as Map
+Left True :: Either Bool b</code></pre>
+<p>So far, we’ve seen that <code>Maybe a</code> was mostly used to
+represent the results of computations that could have either failed or
+not. But sometimes, <code>Maybe a</code> isn’t good enough because
+<code>Nothing</code> doesn’t really convey much information other than
+that something has failed. That’s cool for functions that can fail in
+only one way or if we’re just not interested in how and why they failed.
+A <code>Data.Map</code> lookup fails only if the key we were looking for
+wasn’t in the map, so we know exactly what happened. However, when we’re
+interested in how some function failed or why, we usually use the result
+type of <code>Either a b</code>, where <code>a</code> is some sort of
+type that can tell us something about the possible failure and
+<code>b</code> is the type of a successful computation. Hence, errors
+use the <code>Left</code> value constructor while results use
+<code>Right</code>.</p>
+<p>An example: a high-school has lockers so that students have some
+place to put their Guns’n’Roses posters. Each locker has a code
+combination. When a student wants a new locker, they tell the locker
+supervisor which locker number they want and he gives them the code.
+However, if someone is already using that locker, he can’t tell them the
+code for the locker and they have to pick a different one. We’ll use a
+map from <code>Data.Map</code> to represent the lockers. It’ll map from
+locker numbers to a pair of whether the locker is in use or not and the
+locker code.</p>
+<pre class="haskell:hs"><code>import qualified Data.Map as Map
 
 data LockerState = Taken | Free deriving (Show, Eq)
 
 type Code = String
 
-type LockerMap = Map.Map Int (LockerState, Code)
-</pre>
-<p>Simple stuff. We introduce a new data type to represent whether a locker is taken or free and we make a type synonym for the locker code. We also make a type synonym for the type that maps from integers to pairs of locker state and code. And now, we're going to make a function that searches for the code in a locker map. We're going to use an <span class="fixed">Either String Code</span> type to represent our result, because our lookup can fail in two ways &mdash; the locker can be taken, in which case we can't tell the code or the locker number might not exist at all. If the lookup fails, we're just going to use a <span class="fixed">String</span> to tell what's happened. </p>
-<pre name="code" class="haskell:hs">
-lockerLookup :: Int -&gt; LockerMap -&gt; Either String Code
+type LockerMap = Map.Map Int (LockerState, Code)</code></pre>
+<p>Simple stuff. We introduce a new data type to represent whether a
+locker is taken or free and we make a type synonym for the locker code.
+We also make a type synonym for the type that maps from integers to
+pairs of locker state and code. And now, we’re going to make a function
+that searches for the code in a locker map. We’re going to use an
+<code>Either String Code</code> type to represent our result, because
+our lookup can fail in two ways — the locker can be taken, in which case
+we can’t tell the code or the locker number might not exist at all. If
+the lookup fails, we’re just going to use a <code>String</code> to tell
+what’s happened.</p>
+<pre class="haskell:hs"><code>lockerLookup :: Int -&gt; LockerMap -&gt; Either String Code
 lockerLookup lockerNumber map =
     case Map.lookup lockerNumber map of
-        Nothing -&gt; Left $ "Locker number " ++ show lockerNumber ++ " doesn't exist!"
+        Nothing -&gt; Left $ &quot;Locker number &quot; ++ show lockerNumber ++ &quot; doesn&#39;t exist!&quot;
         Just (state, code) -&gt; if state /= Taken
                                 then Right code
-                                else Left $ "Locker " ++ show lockerNumber ++ " is already taken!"</pre>
-<p>We do a normal lookup in the map. If we get a <span class="fixed">Nothing</span>, we return a value of type <span class="fixed">Left String</span>, saying that the locker doesn't exist at all. If we do find it, then we do an additional check to see if the locker is taken. If it is, return a <span class="fixed">Left</span> saying that it's already taken. If it isn't, then return a value of type <span class="fixed">Right Code</span>, in which we give the student the correct code for the locker. It's actually a <span class="fixed">Right String</span>, but we introduced that type synonym to introduce some additional documentation into the type declaration. Here's an example map:</p>
-<pre name="code" class="haskell:hs">
-lockers :: LockerMap
+                                else Left $ &quot;Locker &quot; ++ show lockerNumber ++ &quot; is already taken!&quot;</code></pre>
+<p>We do a normal lookup in the map. If we get a <code>Nothing</code>,
+we return a value of type <code>Left String</code>, saying that the
+locker doesn’t exist at all. If we do find it, then we do an additional
+check to see if the locker is taken. If it is, return a
+<code>Left</code> saying that it’s already taken. If it isn’t, then
+return a value of type <code>Right Code</code>, in which we give the
+student the correct code for the locker. It’s actually a
+<code>Right String</code>, but we introduced that type synonym to
+introduce some additional documentation into the type declaration.
+Here’s an example map:</p>
+<pre class="haskell:hs"><code>lockers :: LockerMap
 lockers = Map.fromList
-    [(100,(Taken,"ZD39I"))
-    ,(101,(Free,"JAH3I"))
-    ,(103,(Free,"IQSA9"))
-    ,(105,(Free,"QOTSA"))
-    ,(109,(Taken,"893JJ"))
-    ,(110,(Taken,"99292"))
-    ]
-</pre>
-<p>Now let's try looking up some locker codes.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; lockerLookup 101 lockers
-Right "JAH3I"
+    [(100,(Taken,&quot;ZD39I&quot;))
+    ,(101,(Free,&quot;JAH3I&quot;))
+    ,(103,(Free,&quot;IQSA9&quot;))
+    ,(105,(Free,&quot;QOTSA&quot;))
+    ,(109,(Taken,&quot;893JJ&quot;))
+    ,(110,(Taken,&quot;99292&quot;))
+    ]</code></pre>
+<p>Now let’s try looking up some locker codes.</p>
+<pre class="haskell:hs"><code>ghci&gt; lockerLookup 101 lockers
+Right &quot;JAH3I&quot;
 ghci&gt; lockerLookup 100 lockers
-Left "Locker 100 is already taken!"
+Left &quot;Locker 100 is already taken!&quot;
 ghci&gt; lockerLookup 102 lockers
-Left "Locker number 102 doesn't exist!"
+Left &quot;Locker number 102 doesn&#39;t exist!&quot;
 ghci&gt; lockerLookup 110 lockers
-Left "Locker 110 is already taken!"
+Left &quot;Locker 110 is already taken!&quot;
 ghci&gt; lockerLookup 105 lockers
-Right "QOTSA"
-</pre>
-<p>We could have used a <span class="fixed">Maybe a</span> to represent the result but then we wouldn't know why we couldn't get the code. But now, we have information about the failure in our result type.</p>
-<a name="recursive-data-structures"></a><h2>Recursive data structures</h2>
-<img src="assets/images/making-our-own-types-and-typeclasses/thefonz.png" alt="the fonz" class="right" width="168" height="301">
-<p>As we've seen, a constructor in an algebraic data type can have several (or none at all) fields and each field must be of some concrete type. With that in mind, we can make types whose constructors have fields that are of the same type! Using that, we can create recursive data types, where one value of some type contains values of that type, which in turn contain more values of the same type and so on.</p>
-<p>Think about this list: <span class="fixed">[5]</span>. That's just syntactic sugar for <span class="fixed">5:[]</span>. On the left side of the <span class="fixed">:</span>, there's a value and on the right side, there's a list. And in this case, it's an empty list. Now how about the list <span class="fixed">[4,5]</span>? Well, that desugars to <span class="fixed">4:(5:[])</span>. Looking at the first <span class="fixed">:</span>, we see that it also has an element on its left side and a list (<span class="fixed">5:[]</span>) on its right side. Same goes for a list like <span class="fixed">3:(4:(5:6:[]))</span>, which could be written either like that or like <span class="fixed">3:4:5:6:[]</span> (because <span class="fixed">:</span> is right-associative) or <span class="fixed">[3,4,5,6]</span>.</p>
-<p>We could say that a list can be an empty list or it can be an element joined together with a <span class="fixed">:</span> with another list (that can be either the empty list or not).</p>
-<p>Let's use algebraic data types to implement our own list then!</p>
-<pre name="code" class="haskell:hs">
-data List a = Empty | Cons a (List a) deriving (Show, Read, Eq, Ord)
-</pre>
-<p>This reads just like our definition of lists from one of the previous paragraphs. It's either an empty list or a combination of a head with some value and a list. If you're confused about this, you might find it easier to understand in record syntax.</p>
-<pre name="code" class="haskell:hs">
-data List a = Empty | Cons { listHead :: a, listTail :: List a} deriving (Show, Read, Eq, Ord)
-</pre>
-<p>You might also be confused about the <span class="fixed">Cons</span> constructor here. <i>cons</i> is another word for <span class="fixed">:</span>. You see, in lists, <span class="fixed">:</span> is actually a constructor that takes a value and another list and returns a list. We can already use our new list type! In other words, it has two fields. One field is of the type of <span class="fixed">a</span> and the other is of the type <span class="fixed">[a]</span>.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; Empty
+Right &quot;QOTSA&quot;</code></pre>
+<p>We could have used a <code>Maybe a</code> to represent the result but
+then we wouldn’t know why we couldn’t get the code. But now, we have
+information about the failure in our result type.</p>
+<h2 id="recursive-data-structures">Recursive data structures</h2>
+<p><img
+src="assets/images/making-our-own-types-and-typeclasses/thefonz.png"
+class="right" width="168" height="301" alt="the fonz" /></p>
+<p>As we’ve seen, a constructor in an algebraic data type can have
+several (or none at all) fields and each field must be of some concrete
+type. With that in mind, we can make types whose constructors have
+fields that are of the same type! Using that, we can create recursive
+data types, where one value of some type contains values of that type,
+which in turn contain more values of the same type and so on.</p>
+<p>Think about this list: <code>[5]</code>. That’s just syntactic sugar
+for <code>5:[]</code>. On the left side of the <code>:</code>, there’s a
+value and on the right side, there’s a list. And in this case, it’s an
+empty list. Now how about the list <code>[4,5]</code>? Well, that
+desugars to <code>4:(5:[])</code>. Looking at the first <code>:</code>,
+we see that it also has an element on its left side and a list
+(<code>5:[]</code>) on its right side. Same goes for a list like
+<code>3:(4:(5:6:[]))</code>, which could be written either like that or
+like <code>3:4:5:6:[]</code> (because <code>:</code> is
+right-associative) or <code>[3,4,5,6]</code>.</p>
+<p>We could say that a list can be an empty list or it can be an element
+joined together with a <code>:</code> with another list (that can be
+either the empty list or not).</p>
+<p>Let’s use algebraic data types to implement our own list then!</p>
+<pre class="haskell:hs"><code>data List a = Empty | Cons a (List a) deriving (Show, Read, Eq, Ord)</code></pre>
+<p>This reads just like our definition of lists from one of the previous
+paragraphs. It’s either an empty list or a combination of a head with
+some value and a list. If you’re confused about this, you might find it
+easier to understand in record syntax.</p>
+<pre class="haskell:hs"><code>data List a = Empty | Cons { listHead :: a, listTail :: List a} deriving (Show, Read, Eq, Ord)</code></pre>
+<p>You might also be confused about the <code>Cons</code> constructor
+here. <em>cons</em> is another word for <code>:</code>. You see, in
+lists, <code>:</code> is actually a constructor that takes a value and
+another list and returns a list. We can already use our new list type!
+In other words, it has two fields. One field is of the type of
+<code>a</code> and the other is of the type <code>[a]</code>.</p>
+<pre class="haskell:hs"><code>ghci&gt; Empty
 Empty
 ghci&gt; 5 `Cons` Empty
 Cons 5 Empty
 ghci&gt; 4 `Cons` (5 `Cons` Empty)
 Cons 4 (Cons 5 Empty)
 ghci&gt; 3 `Cons` (4 `Cons` (5 `Cons` Empty))
-Cons 3 (Cons 4 (Cons 5 Empty))
-</pre>
-<p>We called our <span class="fixed">Cons</span> constructor in an infix manner so you can see how it's just like <span class="fixed">:</span>. <span class="fixed">Empty</span> is like <span class="fixed">[]</span> and <span class="fixed">4 `Cons` (5 `Cons` Empty)</span> is like <span class="fixed">4:(5:[])</span>.</p>
-<p>We can define functions to be automatically infix by making them comprised of only special characters. We can also do the same with constructors, since they're just functions that return a data type. So check this out.</p>
-<pre name="code" class="haskell:hs">
-infixr 5 :-:
-data List a = Empty | a :-: (List a) deriving (Show, Read, Eq, Ord)
-</pre>
-<p>First off, we notice a new syntactic construct, the fixity declarations. When we define functions as operators, we can use that to give them a fixity (but we don't have to). A fixity states how tightly the operator binds and whether it's left-associative or right-associative. For instance, <span class="fixed">*</span>'s fixity is <span class="fixed">infixl 7 *</span> and <span class="fixed">+</span>'s fixity is <span class="fixed">infixl 6</span>. That means that they're both left-associative (<span class="fixed">4 * 3 * 2</span> is <span class="fixed">(4 * 3) * 2</span>) but <span class="fixed">*</span> binds tighter than <span class="fixed">+</span>, because it has a greater fixity, so <span class="fixed">5 * 4 + 3</span> is <span class="fixed">(5 * 4) + 3</span>.</p>
-<p>Otherwise, we just wrote <span class="fixed">a :-: (List a)</span> instead of <span class="fixed">Cons a (List a)</span>. Now, we can write out lists in our list type like so:</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; 3 :-: 4 :-: 5 :-: Empty
+Cons 3 (Cons 4 (Cons 5 Empty))</code></pre>
+<p>We called our <code>Cons</code> constructor in an infix manner so you
+can see how it’s just like <code>:</code>. <code>Empty</code> is like
+<code>[]</code> and <code>4 `Cons` (5 `Cons` Empty)</code> is like
+<code>4:(5:[])</code>.</p>
+<p>We can define functions to be automatically infix by making them
+comprised of only special characters. We can also do the same with
+constructors, since they’re just functions that return a data type. So
+check this out.</p>
+<pre class="haskell:hs"><code>infixr 5 :-:
+data List a = Empty | a :-: (List a) deriving (Show, Read, Eq, Ord)</code></pre>
+<p>First off, we notice a new syntactic construct, the fixity
+declarations. When we define functions as operators, we can use that to
+give them a fixity (but we don’t have to). A fixity states how tightly
+the operator binds and whether it’s left-associative or
+right-associative. For instance, <code>*</code>’s fixity is
+<code>infixl 7 *</code> and <code>+</code>’s fixity is
+<code>infixl 6</code>. That means that they’re both left-associative
+(<code>4 * 3 * 2</code> is <code>(4 * 3) * 2</code>) but <code>*</code>
+binds tighter than <code>+</code>, because it has a greater fixity, so
+<code>5 * 4 + 3</code> is <code>(5 * 4) + 3</code>.</p>
+<p>Otherwise, we just wrote <code>a :-: (List a)</code> instead of
+<code>Cons a (List a)</code>. Now, we can write out lists in our list
+type like so:</p>
+<pre class="haskell:hs"><code>ghci&gt; 3 :-: 4 :-: 5 :-: Empty
 (:-:) 3 ((:-:) 4 ((:-:) 5 Empty))
 ghci&gt; let a = 3 :-: 4 :-: 5 :-: Empty
 ghci&gt; 100 :-: a
-(:-:) 100 ((:-:) 3 ((:-:) 4 ((:-:) 5 Empty)))
-</pre>
-<p>When deriving <span class="fixed">Show</span> for our type, Haskell will still display it as if the constructor was a prefix function, hence the parentheses around the operator (remember, <span class="fixed">4 + 3</span> is <span class="fixed">(+) 4 3</span>).</p>
-<p>Let's make a function that adds two of our lists together. This is how <span class="fixed">++</span> is defined for normal lists:</p>
-<pre name="code" class="haskell:hs">
-infixr 5  ++
+(:-:) 100 ((:-:) 3 ((:-:) 4 ((:-:) 5 Empty)))</code></pre>
+<p>When deriving <code>Show</code> for our type, Haskell will still
+display it as if the constructor was a prefix function, hence the
+parentheses around the operator (remember, <code>4 + 3</code> is
+<code>(+) 4 3</code>).</p>
+<p>Let’s make a function that adds two of our lists together. This is
+how <code>++</code> is defined for normal lists:</p>
+<pre class="haskell:hs"><code>infixr 5  ++
 (++) :: [a] -&gt; [a] -&gt; [a]
 []     ++ ys = ys
-(x:xs) ++ ys = x : (xs ++ ys)
-</pre>
-<p>So we'll just steal that for our own list. We'll name the function <span class="fixed">.++</span>.</p>
-<pre name="code" class="haskell:hs">
-infixr 5  .++
+(x:xs) ++ ys = x : (xs ++ ys)</code></pre>
+<p>So we’ll just steal that for our own list. We’ll name the function
+<code>.++</code>.</p>
+<pre class="haskell:hs"><code>infixr 5  .++
 (.++) :: List a -&gt; List a -&gt; List a
 Empty .++ ys = ys
-(x :-: xs) .++ ys = x :-: (xs .++ ys)
-</pre>
-<p>And let's see if it works ...</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; let a = 3 :-: 4 :-: 5 :-: Empty
+(x :-: xs) .++ ys = x :-: (xs .++ ys)</code></pre>
+<p>And let’s see if it works …</p>
+<pre class="haskell:hs"><code>ghci&gt; let a = 3 :-: 4 :-: 5 :-: Empty
 ghci&gt; let b = 6 :-: 7 :-: Empty
 ghci&gt; a .++ b
-(:-:) 3 ((:-:) 4 ((:-:) 5 ((:-:) 6 ((:-:) 7 Empty))))
-</pre>
-<p>Nice. Is nice. If we wanted, we could implement all of the functions that operate on lists on our own list type.</p>
-<p>Notice how we pattern matched on <span class="fixed">(x :-: xs)</span>. That works because pattern matching is actually about matching constructors. We can match on <span class="fixed">:-:</span> because it is a constructor for our own list type and we can also match on <span class="fixed">:</span> because it is a constructor for the built-in list type. Same goes for <span class="fixed">[]</span>. Because pattern matching works (only) on constructors, we can match for stuff like that, normal prefix constructors or stuff like <span class="fixed">8</span> or <span class="fixed">'a'</span>, which are basically constructors for the numeric and character types, respectively.</p>
-<img src="assets/images/making-our-own-types-and-typeclasses/binarytree.png" alt="binary search tree" class="left" width="323" height="225">
-<p>Now, we're going to implement a <em>binary search tree</em>. If you're not familiar with binary search trees from languages like C, here's what they are: an element points to two elements, one on its left and one on its right. The element to the left is smaller, the element to the right is bigger. Each of those elements can also point to two elements (or one, or none). In effect, each element has up to two subtrees. And a cool thing about binary search trees is that we know that all the elements at the left subtree of, say, 5 are going to be smaller than 5. Elements in its right subtree are going to be bigger. So if we need to find if 8 is in our tree, we'd start at 5 and then because 8 is greater than 5, we'd go right. We're now at 7 and because 8 is greater than 7, we go right again. And we've found our element in three hops! Now if this were a normal list (or a tree, but really unbalanced), it would take us seven hops instead of three to see if 8 is in there.</p>
-<p>Sets and maps from <span class="fixed">Data.Set</span> and <span class="fixed">Data.Map</span> are implemented using trees, only instead of normal binary search trees, they use balanced binary search trees, which are always balanced. But right now, we'll just be implementing normal binary search trees.</p>
-<p>Here's what we're going to say: a tree is either an empty tree or it's an element that contains some value and two trees. Sounds like a perfect fit for an algebraic data type!</p>
-<pre name="code" class="haskell:hs">
-data Tree a = EmptyTree | Node a (Tree a) (Tree a) deriving (Show, Read, Eq)
-</pre>
-<p>Okay, good, this is good. Instead of manually building a tree, we're going to make a function that takes a tree and an element and inserts an element. We do this by comparing the value we want to insert to the root node and then if it's smaller, we go left, if it's larger, we go right. We do the same for every subsequent node until we reach an empty tree. Once we've reached an empty tree, we just insert a node with that value instead of the empty tree.</p>
-<p>In languages like C, we'd do this by modifying the pointers and values inside the tree. In Haskell, we can't really modify our tree, so we have to make a new subtree each time we decide to go left or right and in the end the insertion function returns a completely new tree, because Haskell doesn't really have a concept of pointer, just values. Hence, the type for our insertion function is going to be something like <span class="fixed">a -&gt; Tree a -&gt; Tree a</span>. It takes an element and a tree and returns a new tree that has that element inside. This might seem like it's inefficient but laziness takes care of that problem.</p>
-<p>So, here are two functions. One is a utility function for making a singleton tree (a tree with just one node) and a function to insert an element into a tree.</p>
-<pre name="code" class="haskell:hs">
-singleton :: a -&gt; Tree a
+(:-:) 3 ((:-:) 4 ((:-:) 5 ((:-:) 6 ((:-:) 7 Empty))))</code></pre>
+<p>Nice. Is nice. If we wanted, we could implement all of the functions
+that operate on lists on our own list type.</p>
+<p>Notice how we pattern matched on <code>(x :-: xs)</code>. That works
+because pattern matching is actually about matching constructors. We can
+match on <code>:-:</code> because it is a constructor for our own list
+type and we can also match on <code>:</code> because it is a constructor
+for the built-in list type. Same goes for <code>[]</code>. Because
+pattern matching works (only) on constructors, we can match for stuff
+like that, normal prefix constructors or stuff like <code>8</code> or
+<code>'a'</code>, which are basically constructors for the numeric and
+character types, respectively.</p>
+<p><img
+src="assets/images/making-our-own-types-and-typeclasses/binarytree.png"
+class="left" width="323" height="225" alt="binary search tree" /></p>
+<p>Now, we’re going to implement a <strong>binary search tree</strong>.
+If you’re not familiar with binary search trees from languages like C,
+here’s what they are: an element points to two elements, one on its left
+and one on its right. The element to the left is smaller, the element to
+the right is bigger. Each of those elements can also point to two
+elements (or one, or none). In effect, each element has up to two
+subtrees. And a cool thing about binary search trees is that we know
+that all the elements at the left subtree of, say, 5 are going to be
+smaller than 5. Elements in its right subtree are going to be bigger. So
+if we need to find if 8 is in our tree, we’d start at 5 and then because
+8 is greater than 5, we’d go right. We’re now at 7 and because 8 is
+greater than 7, we go right again. And we’ve found our element in three
+hops! Now if this were a normal list (or a tree, but really unbalanced),
+it would take us seven hops instead of three to see if 8 is in
+there.</p>
+<p>Sets and maps from <code>Data.Set</code> and <code>Data.Map</code>
+are implemented using trees, only instead of normal binary search trees,
+they use balanced binary search trees, which are always balanced. But
+right now, we’ll just be implementing normal binary search trees.</p>
+<p>Here’s what we’re going to say: a tree is either an empty tree or
+it’s an element that contains some value and two trees. Sounds like a
+perfect fit for an algebraic data type!</p>
+<pre class="haskell:hs"><code>data Tree a = EmptyTree | Node a (Tree a) (Tree a) deriving (Show, Read, Eq)</code></pre>
+<p>Okay, good, this is good. Instead of manually building a tree, we’re
+going to make a function that takes a tree and an element and inserts an
+element. We do this by comparing the value we want to insert to the root
+node and then if it’s smaller, we go left, if it’s larger, we go right.
+We do the same for every subsequent node until we reach an empty tree.
+Once we’ve reached an empty tree, we just insert a node with that value
+instead of the empty tree.</p>
+<p>In languages like C, we’d do this by modifying the pointers and
+values inside the tree. In Haskell, we can’t really modify our tree, so
+we have to make a new subtree each time we decide to go left or right
+and in the end the insertion function returns a completely new tree,
+because Haskell doesn’t really have a concept of pointer, just values.
+Hence, the type for our insertion function is going to be something like
+<code>a -&gt; Tree a -&gt; Tree a</code>. It takes an element and a tree
+and returns a new tree that has that element inside. This might seem
+like it’s inefficient but laziness takes care of that problem.</p>
+<p>So, here are two functions. One is a utility function for making a
+singleton tree (a tree with just one node) and a function to insert an
+element into a tree.</p>
+<pre class="haskell:hs"><code>singleton :: a -&gt; Tree a
 singleton x = Node x EmptyTree EmptyTree
 
 treeInsert :: (Ord a) =&gt; a -&gt; Tree a -&gt; Tree a
@@ -672,185 +1076,382 @@ treeInsert x EmptyTree = singleton x
 treeInsert x (Node a left right)
     | x == a = Node x left right
     | x &lt; a  = Node a (treeInsert x left) right
-    | x &gt; a  = Node a left (treeInsert x right)
-</pre>
-<p>The <span class="fixed">singleton</span> function is just a shortcut for making a node that has something and then two empty subtrees. In the insertion function, we first have the edge condition as a pattern. If we've reached an empty subtree, that means we're where we want and instead of the empty tree, we put a singleton tree with our element. If we're not inserting into an empty tree, then we have to check some things. First off, if the element we're inserting is equal to the root element, just return a tree that's the same. If it's smaller, return a tree that has the same root value, the same right subtree but instead of its left subtree, put a tree that has our value inserted into it. Same (but the other way around) goes if our value is bigger than the root element.</p>
-<p>Next up, we're going to make a function that checks if some element is in the tree. First, let's define the edge condition. If we're looking for an element in an empty tree, then it's certainly not there. Okay. Notice how this is the same as the edge condition when searching for elements in lists. If we're looking for an element in an empty list, it's not there. Anyway, if we're not looking for an element in an empty tree, then we check some things. If the element in the root node is what we're looking for, great! If it's not, what then? Well, we can take advantage of knowing that all the left elements are smaller than the root node. So if the element we're looking for is smaller than the root node, check to see if it's in the left subtree. If it's bigger, check to see if it's in the right subtree.</p>
-<pre name="code" class="haskell:hs">
-treeElem :: (Ord a) =&gt; a -&gt; Tree a -&gt; Bool
+    | x &gt; a  = Node a left (treeInsert x right)</code></pre>
+<p>The <code>singleton</code> function is just a shortcut for making a
+node that has something and then two empty subtrees. In the insertion
+function, we first have the edge condition as a pattern. If we’ve
+reached an empty subtree, that means we’re where we want and instead of
+the empty tree, we put a singleton tree with our element. If we’re not
+inserting into an empty tree, then we have to check some things. First
+off, if the element we’re inserting is equal to the root element, just
+return a tree that’s the same. If it’s smaller, return a tree that has
+the same root value, the same right subtree but instead of its left
+subtree, put a tree that has our value inserted into it. Same (but the
+other way around) goes if our value is bigger than the root element.</p>
+<p>Next up, we’re going to make a function that checks if some element
+is in the tree. First, let’s define the edge condition. If we’re looking
+for an element in an empty tree, then it’s certainly not there. Okay.
+Notice how this is the same as the edge condition when searching for
+elements in lists. If we’re looking for an element in an empty list,
+it’s not there. Anyway, if we’re not looking for an element in an empty
+tree, then we check some things. If the element in the root node is what
+we’re looking for, great! If it’s not, what then? Well, we can take
+advantage of knowing that all the left elements are smaller than the
+root node. So if the element we’re looking for is smaller than the root
+node, check to see if it’s in the left subtree. If it’s bigger, check to
+see if it’s in the right subtree.</p>
+<pre class="haskell:hs"><code>treeElem :: (Ord a) =&gt; a -&gt; Tree a -&gt; Bool
 treeElem x EmptyTree = False
 treeElem x (Node a left right)
     | x == a = True
-    | x < a  = treeElem x left
-    | x &gt; a  = treeElem x right
-</pre>
-<p>All we had to do was write up the previous paragraph in code. Let's have some fun with our trees! Instead of manually building one (although we could), we'll use a fold to build up a tree from a list. Remember, pretty much everything that traverses a list one by one and then returns some sort of value can be implemented with a fold! We're going to start with the empty tree and then approach a list from the right and just insert element after element into our accumulator tree. </p>
-<pre name="code" class="haskell:hs">
-ghci&gt; let nums = [8,6,4,1,7,3,5]
+    | x &lt; a  = treeElem x left
+    | x &gt; a  = treeElem x right</code></pre>
+<p>All we had to do was write up the previous paragraph in code. Let’s
+have some fun with our trees! Instead of manually building one (although
+we could), we’ll use a fold to build up a tree from a list. Remember,
+pretty much everything that traverses a list one by one and then returns
+some sort of value can be implemented with a fold! We’re going to start
+with the empty tree and then approach a list from the right and just
+insert element after element into our accumulator tree.</p>
+<pre class="haskell:hs"><code>ghci&gt; let nums = [8,6,4,1,7,3,5]
 ghci&gt; let numsTree = foldr treeInsert EmptyTree nums
 ghci&gt; numsTree
-Node 5 (Node 3 (Node 1 EmptyTree EmptyTree) (Node 4 EmptyTree EmptyTree)) (Node 7 (Node 6 EmptyTree EmptyTree) (Node 8 EmptyTree EmptyTree))</pre>
-<p>In that <span class="fixed">foldr</span>, <span class="fixed">treeInsert</span> was the folding function (it takes a tree and a list element and produces a new tree) and <span class="fixed">EmptyTree</span> was the starting accumulator. <span class="fixed">nums</span>, of course, was the list we were folding over.</p>
-<p>When we print our tree to the console, it's not very readable, but if we try, we can make out its structure. We see that the root node is 5 and then it has two subtrees, one of which has the root node of 3 and the other a 7, etc.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; 8 `treeElem` numsTree
+Node 5 (Node 3 (Node 1 EmptyTree EmptyTree) (Node 4 EmptyTree EmptyTree)) (Node 7 (Node 6 EmptyTree EmptyTree) (Node 8 EmptyTree EmptyTree))</code></pre>
+<p>In that <code>foldr</code>, <code>treeInsert</code> was the folding
+function (it takes a tree and a list element and produces a new tree)
+and <code>EmptyTree</code> was the starting accumulator.
+<code>nums</code>, of course, was the list we were folding over.</p>
+<p>When we print our tree to the console, it’s not very readable, but if
+we try, we can make out its structure. We see that the root node is 5
+and then it has two subtrees, one of which has the root node of 3 and
+the other a 7, etc.</p>
+<pre class="haskell:hs"><code>ghci&gt; 8 `treeElem` numsTree
 True
 ghci&gt; 100 `treeElem` numsTree
 False
 ghci&gt; 1 `treeElem` numsTree
 True
 ghci&gt; 10 `treeElem` numsTree
-False
-</pre>
+False</code></pre>
 <p>Checking for membership also works nicely. Cool.</p>
-<p>So as you can see, algebraic data structures are a really cool and powerful concept in Haskell. We can use them to make anything from boolean values and weekday enumerations to binary search trees and more!</p>
-<a name="typeclasses-102"></a><h2>Typeclasses 102</h2>
-<img src="assets/images/making-our-own-types-and-typeclasses/trafficlight.png" alt="tweet" class="right" width="175" height="480">
-<p>So far, we've learned about some of the standard Haskell typeclasses and we've seen which types are in them. We've also learned how to automatically make our own types instances of the standard typeclasses by asking Haskell to derive the instances for us. In this section, we're going to learn how to make our own typeclasses and how to make types instances of them by hand.</p>
-<p>A quick recap on typeclasses: typeclasses are like interfaces. A typeclass defines some behavior (like comparing for equality, comparing for ordering, enumeration) and then types that can behave in that way are made instances of that typeclass. The behavior of typeclasses is achieved by defining functions or just type declarations that we then implement. So when we say that a type is an instance of a typeclass, we mean that we can use the functions that the typeclass defines with that type.</p>
-<p>Typeclasses have pretty much nothing to do with classes in languages like Java or Python. This confuses many people, so I want you to forget everything you know about classes in imperative languages right now.</p>
-<p>For example, the <span class="fixed">Eq</span> typeclass is for stuff that can be equated. It defines the functions <span class="fixed">==</span> and <span class="fixed">/=</span>. If we have a type (say, <span class="fixed">Car</span>) and comparing two cars with the equality function <span class="fixed">==</span> makes sense, then it makes sense for <span class="fixed">Car</span> to be an instance of <span class="fixed">Eq</span>.</p>
-<p>This is how the <span class="fixed">Eq</span> class is defined in the standard prelude:</p>
-<pre name="code" class="haskell:hs">
-class Eq a where
+<p>So as you can see, algebraic data structures are a really cool and
+powerful concept in Haskell. We can use them to make anything from
+boolean values and weekday enumerations to binary search trees and
+more!</p>
+<h2 id="typeclasses-102">Typeclasses 102</h2>
+<p><img
+src="assets/images/making-our-own-types-and-typeclasses/trafficlight.png"
+class="right" width="175" height="480" alt="tweet" /></p>
+<p>So far, we’ve learned about some of the standard Haskell typeclasses
+and we’ve seen which types are in them. We’ve also learned how to
+automatically make our own types instances of the standard typeclasses
+by asking Haskell to derive the instances for us. In this section, we’re
+going to learn how to make our own typeclasses and how to make types
+instances of them by hand.</p>
+<p>A quick recap on typeclasses: typeclasses are like interfaces. A
+typeclass defines some behavior (like comparing for equality, comparing
+for ordering, enumeration) and then types that can behave in that way
+are made instances of that typeclass. The behavior of typeclasses is
+achieved by defining functions or just type declarations that we then
+implement. So when we say that a type is an instance of a typeclass, we
+mean that we can use the functions that the typeclass defines with that
+type.</p>
+<p>Typeclasses have pretty much nothing to do with classes in languages
+like Java or Python. This confuses many people, so I want you to forget
+everything you know about classes in imperative languages right now.</p>
+<p>For example, the <code>Eq</code> typeclass is for stuff that can be
+equated. It defines the functions <code>==</code> and <code>/=</code>.
+If we have a type (say, <code>Car</code>) and comparing two cars with
+the equality function <code>==</code> makes sense, then it makes sense
+for <code>Car</code> to be an instance of <code>Eq</code>.</p>
+<p>This is how the <code>Eq</code> class is defined in the standard
+prelude:</p>
+<pre class="haskell:hs"><code>class Eq a where
     (==) :: a -&gt; a -&gt; Bool
     (/=) :: a -&gt; a -&gt; Bool
     x == y = not (x /= y)
-    x /= y = not (x == y)
-</pre>
-<p>Woah, woah, woah! Some new strange syntax and keywords there! Don't worry, this will all be clear in a second. First off, when we write <span class="fixed">class Eq a where</span>, this means that we're defining a new typeclass and that's called <span class="fixed">Eq</span>. The <span class="fixed">a</span> is the type variable and it means that <span class="fixed">a</span> will play the role of the type that we will soon be making an instance of <span class="fixed">Eq</span>. It doesn't have to be called <span class="fixed">a</span>, it doesn't even have to be one letter, it just has to be a lowercase word. Then, we define several functions. It's not mandatory to implement the function bodies themselves, we just have to specify the type declarations for the functions.</p>
-<div class="hintbox">Some people might understand this better if we wrote <span class="fixed">class Eq equatable where</span> and then specified the type declarations like <span class="fixed">(==) :: equatable -&gt; equatable -&gt; Bool</span>.</div>
-<p>Anyway, we <i>did</i> implement the function bodies for the functions that <span class="fixed">Eq</span> defines, only we defined them in terms of mutual recursion. We said that two instances of <span class="fixed">Eq</span> are equal if they are not different and they are different if they are not equal. We didn't have to do this, really, but we did and we'll see how this helps us soon.</p>
-<div class="hintbox">If we have say <span class="fixed">class Eq a where</span> and then define a type declaration within that class like <span class="fixed">(==) :: a -&gt; a -&gt; Bool</span>, then when we examine the type of that function later on, it will have the type of <span class="fixed">(Eq a) =&gt; a -&gt; a -&gt; Bool</span>.</div>
-<p>So once we have a class, what can we do with it? Well, not much, really. But once we start making types instances of that class, we start getting some nice functionality. So check out this type:</p>
-<pre name="code" class="haskell:hs">
-data TrafficLight = Red | Yellow | Green
-</pre>
-<p>It defines the states of a traffic light. Notice how we didn't derive any class instances for it. That's because we're going to write up some instances by hand, even though we could derive them for types like <span class="fixed">Eq</span> and <span class="fixed">Show</span>. Here's how we make it an instance of <span class="fixed">Eq</span>.</p>
-<pre name="code" class="haskell:hs">
-instance Eq TrafficLight where
+    x /= y = not (x == y)</code></pre>
+<p>Woah, woah, woah! Some new strange syntax and keywords there! Don’t
+worry, this will all be clear in a second. First off, when we write
+<code>class Eq a where</code>, this means that we’re defining a new
+typeclass and that’s called <code>Eq</code>. The <code>a</code> is the
+type variable and it means that <code>a</code> will play the role of the
+type that we will soon be making an instance of <code>Eq</code>. It
+doesn’t have to be called <code>a</code>, it doesn’t even have to be one
+letter, it just has to be a lowercase word. Then, we define several
+functions. It’s not mandatory to implement the function bodies
+themselves, we just have to specify the type declarations for the
+functions.</p>
+<div class="hintbox">
+<p>Some people might understand this better if we wrote
+<code>class Eq equatable where</code> and then specified the type
+declarations like
+<code>(==) :: equatable -&gt; equatable -&gt; Bool</code>.</p>
+</div>
+<p>Anyway, we <em>did</em> implement the function bodies for the
+functions that <code>Eq</code> defines, only we defined them in terms of
+mutual recursion. We said that two instances of <code>Eq</code> are
+equal if they are not different and they are different if they are not
+equal. We didn’t have to do this, really, but we did and we’ll see how
+this helps us soon.</p>
+<div class="hintbox">
+<p>If we have say <code>class Eq a where</code> and then define a type
+declaration within that class like
+<code>(==) :: a -&gt; a -&gt; Bool</code>, then when we examine the type
+of that function later on, it will have the type of
+<code>(Eq a) =&gt; a -&gt; a -&gt; Bool</code>.</p>
+</div>
+<p>So once we have a class, what can we do with it? Well, not much,
+really. But once we start making types instances of that class, we start
+getting some nice functionality. So check out this type:</p>
+<pre class="haskell:hs"><code>data TrafficLight = Red | Yellow | Green</code></pre>
+<p>It defines the states of a traffic light. Notice how we didn’t derive
+any class instances for it. That’s because we’re going to write up some
+instances by hand, even though we could derive them for types like
+<code>Eq</code> and <code>Show</code>. Here’s how we make it an instance
+of <code>Eq</code>.</p>
+<pre class="haskell:hs"><code>instance Eq TrafficLight where
     Red == Red = True
     Green == Green = True
     Yellow == Yellow = True
-    _ == _ = False
-</pre>
-<p>We did it by using the <i>instance</i> keyword. So <i>class</i> is for defining new typeclasses and <i>instance</i> is for making our types instances of typeclasses. When we were defining <span class="fixed">Eq</span>, we wrote <span class="fixed">class Eq a where</span> and we said that <span class="fixed">a</span> plays the role of whichever type will be made an instance later on. We can see that clearly here, because when we're making an instance, we write <span class="fixed">instance Eq TrafficLight where</span>. We replace the <span class="fixed">a</span> with the actual type.</p>
-<p>Because <span class="fixed">==</span> was defined in terms of <span class="fixed">/=</span> and vice versa in the <i>class</i> declaration, we only had to overwrite one of them in the instance declaration. That's called the minimal complete definition for the typeclass &mdash; the minimum of functions that we have to implement so that our type can behave like the class advertises. To fulfill the minimal complete definition for <span class="fixed">Eq</span>, we have to overwrite either one of <span class="fixed">==</span> or <span class="fixed">/=</span>. If <span class="fixed">Eq</span> was defined simply like this:</p>
-<pre name="code" class="haskell:hs">
-class Eq a where
+    _ == _ = False</code></pre>
+<p>We did it by using the <em>instance</em> keyword. So <em>class</em>
+is for defining new typeclasses and <em>instance</em> is for making our
+types instances of typeclasses. When we were defining <code>Eq</code>,
+we wrote <code>class Eq a where</code> and we said that <code>a</code>
+plays the role of whichever type will be made an instance later on. We
+can see that clearly here, because when we’re making an instance, we
+write <code>instance Eq TrafficLight where</code>. We replace the
+<code>a</code> with the actual type.</p>
+<p>Because <code>==</code> was defined in terms of <code>/=</code> and
+vice versa in the <em>class</em> declaration, we only had to overwrite
+one of them in the instance declaration. That’s called the minimal
+complete definition for the typeclass — the minimum of functions that we
+have to implement so that our type can behave like the class advertises.
+To fulfill the minimal complete definition for <code>Eq</code>, we have
+to overwrite either one of <code>==</code> or <code>/=</code>. If
+<code>Eq</code> was defined simply like this:</p>
+<pre class="haskell:hs"><code>class Eq a where
     (==) :: a -&gt; a -&gt; Bool
-    (/=) :: a -&gt; a -&gt; Bool
-</pre>
-<p>we'd have to implement both of these functions when making a type an instance of it, because Haskell wouldn't know how these two functions are related. The minimal complete definition would then be: both <span class="fixed">==</span> and <span class="fixed">/=</span>.</p>
-<p>You can see that we implemented <span class="fixed">==</span> simply by doing pattern matching. Since there are many more cases where two lights aren't equal, we specified the ones that are equal and then just did a catch-all pattern saying that if it's none of the previous combinations, then two lights aren't equal.</p>
-<p>Let's make this an instance of <span class="fixed">Show</span> by hand, too. To satisfy the minimal complete definition for <span class="fixed">Show</span>, we just have to implement its <span class="fixed">show</span> function, which takes a value and turns it into a string.</p>
-<pre name="code" class="haskell:hs">
-instance Show TrafficLight where
-    show Red = "Red light"
-    show Yellow = "Yellow light"
-    show Green = "Green light"
-</pre>
-<p>Once again, we used pattern matching to achieve our goals. Let's see how it works in action:</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; Red == Red
+    (/=) :: a -&gt; a -&gt; Bool</code></pre>
+<p>we’d have to implement both of these functions when making a type an
+instance of it, because Haskell wouldn’t know how these two functions
+are related. The minimal complete definition would then be: both
+<code>==</code> and <code>/=</code>.</p>
+<p>You can see that we implemented <code>==</code> simply by doing
+pattern matching. Since there are many more cases where two lights
+aren’t equal, we specified the ones that are equal and then just did a
+catch-all pattern saying that if it’s none of the previous combinations,
+then two lights aren’t equal.</p>
+<p>Let’s make this an instance of <code>Show</code> by hand, too. To
+satisfy the minimal complete definition for <code>Show</code>, we just
+have to implement its <code>show</code> function, which takes a value
+and turns it into a string.</p>
+<pre class="haskell:hs"><code>instance Show TrafficLight where
+    show Red = &quot;Red light&quot;
+    show Yellow = &quot;Yellow light&quot;
+    show Green = &quot;Green light&quot;</code></pre>
+<p>Once again, we used pattern matching to achieve our goals. Let’s see
+how it works in action:</p>
+<pre class="haskell:hs"><code>ghci&gt; Red == Red
 True
 ghci&gt; Red == Yellow
 False
 ghci&gt; Red `elem` [Red, Yellow, Green]
 True
 ghci&gt; [Red, Yellow, Green]
-[Red light,Yellow light,Green light]
-</pre>
-<p>Nice. We could have just derived <span class="fixed">Eq</span> and it would have had the same effect (but we didn't for educational purposes). However, deriving <span class="fixed">Show</span> would have just directly translated the value constructors to strings. But if we want lights to appear like <span class="fixed">"Red light"</span>, then we have to make the instance declaration by hand.</p>
-<p>You can also make typeclasses that are subclasses of other typeclasses. The <i>class</i> declaration for <span class="fixed">Num</span> is a bit long, but here's the first part:</p>
-<pre name="code" class="haskell:hs">
-class (Eq a) =&gt; Num a where
-   ...  </pre>
-<p>As we mentioned previously, there are a lot of places where we can cram in class constraints. So this is just like writing <span class="fixed">class Num a where</span>, only we state that our type <span class="fixed">a</span> must be an instance of <span class="fixed">Eq</span>. We're essentially saying that we have to make a type an instance of <span class="fixed">Eq</span> before we can make it an instance of <span class="fixed">Num</span>. Before some type can be considered a number, it makes sense that we can determine whether values of that type can be equated or not. That's all there is to subclassing really, it's just a class constraint on a <i>class</i> declaration! When defining function bodies in the <i>class</i> declaration or when defining them in <i>instance</i> declarations, we can assume that <span class="fixed">a</span> is a part of <span class="fixed">Eq</span> and so we can use <span class="fixed">==</span> on values of that type.</p>
-<p>But how are the <span class="fixed">Maybe</span> or list types made as instances of typeclasses? What makes <span class="fixed">Maybe</span> different from, say, <span class="fixed">TrafficLight</span> is that <span class="fixed">Maybe</span> in itself isn't a concrete type, it's a type constructor that takes one type parameter (like <span class="fixed">Char</span> or something) to produce a concrete type (like <span class="fixed">Maybe Char</span>). Let's take a look at the <span class="fixed">Eq</span> typeclass again:</p>
-<pre name="code" class="haskell:hs">
-class Eq a where
+[Red light,Yellow light,Green light]</code></pre>
+<p>Nice. We could have just derived <code>Eq</code> and it would have
+had the same effect (but we didn’t for educational purposes). However,
+deriving <code>Show</code> would have just directly translated the value
+constructors to strings. But if we want lights to appear like
+<code>"Red light"</code>, then we have to make the instance declaration
+by hand.</p>
+<p>You can also make typeclasses that are subclasses of other
+typeclasses. The <em>class</em> declaration for <code>Num</code> is a
+bit long, but here’s the first part:</p>
+<pre class="haskell:hs"><code>class (Eq a) =&gt; Num a where
+   ...</code></pre>
+<p>As we mentioned previously, there are a lot of places where we can
+cram in class constraints. So this is just like writing
+<code>class Num a where</code>, only we state that our type
+<code>a</code> must be an instance of <code>Eq</code>. We’re essentially
+saying that we have to make a type an instance of <code>Eq</code> before
+we can make it an instance of <code>Num</code>. Before some type can be
+considered a number, it makes sense that we can determine whether values
+of that type can be equated or not. That’s all there is to subclassing
+really, it’s just a class constraint on a <em>class</em> declaration!
+When defining function bodies in the <em>class</em> declaration or when
+defining them in <em>instance</em> declarations, we can assume that
+<code>a</code> is a part of <code>Eq</code> and so we can use
+<code>==</code> on values of that type.</p>
+<p>But how are the <code>Maybe</code> or list types made as instances of
+typeclasses? What makes <code>Maybe</code> different from, say,
+<code>TrafficLight</code> is that <code>Maybe</code> in itself isn’t a
+concrete type, it’s a type constructor that takes one type parameter
+(like <code>Char</code> or something) to produce a concrete type (like
+<code>Maybe Char</code>). Let’s take a look at the <code>Eq</code>
+typeclass again:</p>
+<pre class="haskell:hs"><code>class Eq a where
     (==) :: a -&gt; a -&gt; Bool
     (/=) :: a -&gt; a -&gt; Bool
     x == y = not (x /= y)
-    x /= y = not (x == y) </pre>
-<p>From the type declarations, we see that the <span class="fixed">a</span> is used as a concrete type because all the types in functions have to be concrete (remember, you can't have a function of the type <span class="fixed">a -&gt; Maybe</span> but you can have a function of <span class="fixed">a -&gt; Maybe a</span> or <span class="fixed">Maybe Int -&gt; Maybe String</span>). That's why we can't do something like</p>
-<pre name="code" class="haskell:hs">
-instance Eq Maybe where
-    ...  </pre>
-<p>Because like we've seen, the <span class="fixed">a</span> has to be a concrete type but <span class="fixed">Maybe</span> isn't a concrete type. It's a type constructor that takes one parameter and then produces a concrete type. It would also be tedious to write <span class="fixed">instance Eq (Maybe Int) where</span>, <span class="fixed">instance Eq (Maybe Char) where</span>, etc. for every type ever. So we could write it out like so:</p>
-<pre name="code" class="haskell:hs">
-instance Eq (Maybe m) where
+    x /= y = not (x == y)</code></pre>
+<p>From the type declarations, we see that the <code>a</code> is used as
+a concrete type because all the types in functions have to be concrete
+(remember, you can’t have a function of the type
+<code>a -&gt; Maybe</code> but you can have a function of
+<code>a -&gt; Maybe a</code> or
+<code>Maybe Int -&gt; Maybe String</code>). That’s why we can’t do
+something like</p>
+<pre class="haskell:hs"><code>instance Eq Maybe where
+    ...</code></pre>
+<p>Because like we’ve seen, the <code>a</code> has to be a concrete type
+but <code>Maybe</code> isn’t a concrete type. It’s a type constructor
+that takes one parameter and then produces a concrete type. It would
+also be tedious to write <code>instance Eq (Maybe Int) where</code>,
+<code>instance Eq (Maybe Char) where</code>, etc. for every type ever.
+So we could write it out like so:</p>
+<pre class="haskell:hs"><code>instance Eq (Maybe m) where
     Just x == Just y = x == y
     Nothing == Nothing = True
-    _ == _ = False
-      </pre>
-<p>This is like saying that we want to make all types of the form <span class="fixed">Maybe something</span> an instance of <span class="fixed">Eq</span>. We actually could have written <span class="fixed">(Maybe something)</span>, but we usually opt for single letters to be true to the Haskell style. The <span class="fixed">(Maybe m)</span> here plays the role of the <span class="fixed">a</span> from <span class="fixed">class Eq a where</span>. While <span class="fixed">Maybe</span> isn't a concrete type, <span class="fixed">Maybe m</span> is. By specifying a type parameter (<span class="fixed">m</span>, which is in lowercase), we said that we want all types that are in the form of <span class="fixed">Maybe m</span>, where <span class="fixed">m</span> is any type, to be an instance of <span class="fixed">Eq</span>.</p>
-<p>There's one problem with this though. Can you spot it? We use <span class="fixed">==</span> on the contents of the <span class="fixed">Maybe</span> but we have no assurance that what the <span class="fixed">Maybe</span> contains can be used with <span class="fixed">Eq</span>! That's why we have to modify our <i>instance</i> declaration like this:</p>
-<pre name="code" class="haskell:hs">
-instance (Eq m) =&gt; Eq (Maybe m) where
+    _ == _ = False</code></pre>
+<p>This is like saying that we want to make all types of the form
+<code>Maybe something</code> an instance of <code>Eq</code>. We actually
+could have written <code>(Maybe something)</code>, but we usually opt
+for single letters to be true to the Haskell style. The
+<code>(Maybe m)</code> here plays the role of the <code>a</code> from
+<code>class Eq a where</code>. While <code>Maybe</code> isn’t a concrete
+type, <code>Maybe m</code> is. By specifying a type parameter
+(<code>m</code>, which is in lowercase), we said that we want all types
+that are in the form of <code>Maybe m</code>, where <code>m</code> is
+any type, to be an instance of <code>Eq</code>.</p>
+<p>There’s one problem with this though. Can you spot it? We use
+<code>==</code> on the contents of the <code>Maybe</code> but we have no
+assurance that what the <code>Maybe</code> contains can be used with
+<code>Eq</code>! That’s why we have to modify our <em>instance</em>
+declaration like this:</p>
+<pre class="haskell:hs"><code>instance (Eq m) =&gt; Eq (Maybe m) where
     Just x == Just y = x == y
     Nothing == Nothing = True
-    _ == _ = False
-      </pre>
-<p>We had to add a class constraint! With this <i>instance</i> declaration, we say this: we want all types of the form <span class="fixed">Maybe m</span> to be part of the <span class="fixed">Eq</span> typeclass, but only those types where the <span class="fixed">m</span> (so what's contained inside the <span class="fixed">Maybe</span>) is also a part of <span class="fixed">Eq</span>. This is actually how Haskell would derive the instance too.</p>
-<p>Most of the times, class constraints in <i>class</i> declarations are used for making a typeclass a subclass of another typeclass and class constraints in <i>instance</i> declarations are used to express requirements about the contents of some type. For instance, here we required the contents of the <span class="fixed">Maybe</span> to also be part of the <span class="fixed">Eq</span> typeclass.</p>
-<p>When making instances, if you see that a type is used as a concrete type in the type declarations (like the <span class="fixed">a</span> in <span class="fixed">a -&gt; a -&gt; Bool</span>), you have to supply type parameters and add parentheses so that you end up with a concrete type.</p>
-<div class="hintbox">Take into account that the type you're trying to make an instance of will replace the parameter in the <i>class</i> declaration. The <span class="fixed">a</span> from <span class="fixed">class Eq a where</span> will be replaced with a real type when you make an instance, so try mentally putting your type into the function type declarations as well. <span class="fixed">(==) :: Maybe -&gt; Maybe -&gt; Bool</span> doesn't make much sense but <span class="fixed">(==) :: (Eq m) =&gt; Maybe m -&gt; Maybe m -&gt; Bool</span> does. But this is just something to think about, because <span class="fixed">==</span> will always have a type of <span class="fixed">(==) :: (Eq a) =&gt; a -&gt; a -&gt; Bool</span>, no matter what instances we make.</div>
-<p>Ooh, one more thing, check this out! If you want to see what the instances of a typeclass are, just do <span class="fixed">:info YourTypeClass</span> in GHCI. So typing <span class="fixed">:info Num</span> will show which functions the typeclass defines and it will give you a list of the types in the typeclass. <span class="fixed">:info</span> works for types and type constructors too. If you do <span class="fixed">:info Maybe</span>, it will show you all the typeclasses that <span class="fixed">Maybe</span> is an instance of. Also <span class="fixed">:info</span> can show you the type declaration of a function. I think that's pretty cool.</p>
-<a name="a-yes-no-typeclass"></a><h2>A yes-no typeclass</h2>
-<img src="assets/images/making-our-own-types-and-typeclasses/yesno.png" alt="yesno" class="left" width="201" height="111">
-<p>In JavaScript and some other weakly typed languages, you can put almost anything inside an if expression. For example, you can do all of the following: <span class="fixed">if (0) alert("YEAH!") else alert("NO!")</span>, <span class="fixed">if ("") alert ("YEAH!") else alert("NO!")</span>, <span class="fixed">if (false) alert("YEAH") else alert("NO!)</span>, etc. and all of these will throw an alert of <span class="fixed">NO!</span>. If you do <span class="fixed">if ("WHAT") alert ("YEAH") else alert("NO!")</span>, it will alert a <span class="fixed">"YEAH!"</span> because JavaScript considers non-empty strings to be a sort of true-ish value.</p>
-<p>Even though strictly using <span class="fixed">Bool</span> for boolean semantics works better in Haskell, let's try and implement that JavaScript-ish behavior anyway. For fun! Let's start out with a <i>class</i> declaration.</p>
-<pre name="code" class="haskell:hs">
-class YesNo a where
-    yesno :: a -&gt; Bool
-</pre>
-<p>Pretty simple. The <span class="fixed">YesNo</span> typeclass defines one function. That function takes one value of a type that can be considered to hold some concept of true-ness and tells us for sure if it's true or not. Notice that from the way we use the <span class="fixed">a</span> in the function, <span class="fixed">a</span> has to be a concrete type.</p>
-<p>Next up, let's define some instances. For numbers, we'll assume that (like in JavaScript) any number that isn't 0 is true-ish and 0 is false-ish.</p>
-<pre name="code" class="haskell:hs">
-instance YesNo Int where
+    _ == _ = False</code></pre>
+<p>We had to add a class constraint! With this <em>instance</em>
+declaration, we say this: we want all types of the form
+<code>Maybe m</code> to be part of the <code>Eq</code> typeclass, but
+only those types where the <code>m</code> (so what’s contained inside
+the <code>Maybe</code>) is also a part of <code>Eq</code>. This is
+actually how Haskell would derive the instance too.</p>
+<p>Most of the times, class constraints in <em>class</em> declarations
+are used for making a typeclass a subclass of another typeclass and
+class constraints in <em>instance</em> declarations are used to express
+requirements about the contents of some type. For instance, here we
+required the contents of the <code>Maybe</code> to also be part of the
+<code>Eq</code> typeclass.</p>
+<p>When making instances, if you see that a type is used as a concrete
+type in the type declarations (like the <code>a</code> in
+<code>a -&gt; a -&gt; Bool</code>), you have to supply type parameters
+and add parentheses so that you end up with a concrete type.</p>
+<div class="hintbox">
+<p>Take into account that the type you’re trying to make an instance of
+will replace the parameter in the <em>class</em> declaration. The
+<code>a</code> from <code>class Eq a where</code> will be replaced with
+a real type when you make an instance, so try mentally putting your type
+into the function type declarations as well.
+<code>(==) :: Maybe -&gt; Maybe -&gt; Bool</code> doesn’t make much
+sense but
+<code>(==) :: (Eq m) =&gt; Maybe m -&gt; Maybe m -&gt; Bool</code> does.
+But this is just something to think about, because <code>==</code> will
+always have a type of
+<code>(==) :: (Eq a) =&gt; a -&gt; a -&gt; Bool</code>, no matter what
+instances we make.</p>
+</div>
+<p>Ooh, one more thing, check this out! If you want to see what the
+instances of a typeclass are, just do <code>:info YourTypeClass</code>
+in GHCI. So typing <code>:info Num</code> will show which functions the
+typeclass defines and it will give you a list of the types in the
+typeclass. <code>:info</code> works for types and type constructors too.
+If you do <code>:info Maybe</code>, it will show you all the typeclasses
+that <code>Maybe</code> is an instance of. Also <code>:info</code> can
+show you the type declaration of a function. I think that’s pretty
+cool.</p>
+<h2 id="a-yes-no-typeclass">A yes-no typeclass</h2>
+<p><img
+src="assets/images/making-our-own-types-and-typeclasses/yesno.png"
+class="left" width="201" height="111" alt="yesno" /></p>
+<p>In JavaScript and some other weakly typed languages, you can put
+almost anything inside an if expression. For example, you can do all of
+the following: <code>if (0) alert("YEAH!") else alert("NO!")</code>,
+<code>if ("") alert ("YEAH!") else alert("NO!")</code>,
+<code>if (false) alert("YEAH") else alert("NO!)</code>, etc. and all of
+these will throw an alert of <code>NO!</code>. If you do
+<code>if ("WHAT") alert ("YEAH") else alert("NO!")</code>, it will alert
+a <code>"YEAH!"</code> because JavaScript considers non-empty strings to
+be a sort of true-ish value.</p>
+<p>Even though strictly using <code>Bool</code> for boolean semantics
+works better in Haskell, let’s try and implement that JavaScript-ish
+behavior anyway. For fun! Let’s start out with a <em>class</em>
+declaration.</p>
+<pre class="haskell:hs"><code>class YesNo a where
+    yesno :: a -&gt; Bool</code></pre>
+<p>Pretty simple. The <code>YesNo</code> typeclass defines one function.
+That function takes one value of a type that can be considered to hold
+some concept of true-ness and tells us for sure if it’s true or not.
+Notice that from the way we use the <code>a</code> in the function,
+<code>a</code> has to be a concrete type.</p>
+<p>Next up, let’s define some instances. For numbers, we’ll assume that
+(like in JavaScript) any number that isn’t 0 is true-ish and 0 is
+false-ish.</p>
+<pre class="haskell:hs"><code>instance YesNo Int where
     yesno 0 = False
-    yesno _ = True
-</pre>
-<p>Empty lists (and by extensions, strings) are a no-ish value, while non-empty lists are a yes-ish value.</p>
-<pre name="code" class="haskell:hs">
-instance YesNo [a] where
+    yesno _ = True</code></pre>
+<p>Empty lists (and by extensions, strings) are a no-ish value, while
+non-empty lists are a yes-ish value.</p>
+<pre class="haskell:hs"><code>instance YesNo [a] where
     yesno [] = False
-    yesno _ = True
-</pre>
-<p>Notice how we just put in a type parameter <span class="fixed">a</span> in there to make the list a concrete type, even though we don't make any assumptions about the type that's contained in the list. What else, hmm ... I know, <span class="fixed">Bool</span> itself also holds true-ness and false-ness and it's pretty obvious which is which.</p>
-<pre name="code" class="haskell:hs">
-instance YesNo Bool where
-    yesno = id
-</pre>
-<p>Huh? What's <span class="fixed">id</span>? It's just a standard library function that takes a parameter and returns the same thing, which is what we would be writing here anyway.</p>
-<p>Let's make <span class="fixed">Maybe a</span> an instance too.</p>
-<pre name="code" class="haskell:hs">
-instance YesNo (Maybe a) where
+    yesno _ = True</code></pre>
+<p>Notice how we just put in a type parameter <code>a</code> in there to
+make the list a concrete type, even though we don’t make any assumptions
+about the type that’s contained in the list. What else, hmm … I know,
+<code>Bool</code> itself also holds true-ness and false-ness and it’s
+pretty obvious which is which.</p>
+<pre class="haskell:hs"><code>instance YesNo Bool where
+    yesno = id</code></pre>
+<p>Huh? What’s <code>id</code>? It’s just a standard library function
+that takes a parameter and returns the same thing, which is what we
+would be writing here anyway.</p>
+<p>Let’s make <code>Maybe a</code> an instance too.</p>
+<pre class="haskell:hs"><code>instance YesNo (Maybe a) where
     yesno (Just _) = True
-    yesno Nothing = False
-</pre>
-<p>We didn't need a class constraint because we made no assumptions about the contents of the <span class="fixed">Maybe</span>. We just said that it's true-ish if it's a <span class="fixed">Just</span> value and false-ish if it's a <span class="fixed">Nothing</span>. We still had to write out <span class="fixed">(Maybe a)</span> instead of just <span class="fixed">Maybe</span> because if you think about it, a <span class="fixed">Maybe -&gt; Bool</span> function can't exist (because <span class="fixed">Maybe</span> isn't a concrete type), whereas a <span class="fixed">Maybe a -&gt; Bool</span> is fine and dandy. Still, this is really cool because now, any type of the form <span class="fixed">Maybe something</span> is part of <span class="fixed">YesNo</span> and it doesn't matter what that <span class="fixed">something</span> is.</p>
-<p>Previously, we defined a <span class="fixed">Tree a</span> type, that represented a binary search tree. We can say an empty tree is false-ish and anything that's not an empty tree is true-ish.</p>
-<pre name="code" class="haskell:hs">
-instance YesNo (Tree a) where
+    yesno Nothing = False</code></pre>
+<p>We didn’t need a class constraint because we made no assumptions
+about the contents of the <code>Maybe</code>. We just said that it’s
+true-ish if it’s a <code>Just</code> value and false-ish if it’s a
+<code>Nothing</code>. We still had to write out <code>(Maybe a)</code>
+instead of just <code>Maybe</code> because if you think about it, a
+<code>Maybe -&gt; Bool</code> function can’t exist (because
+<code>Maybe</code> isn’t a concrete type), whereas a
+<code>Maybe a -&gt; Bool</code> is fine and dandy. Still, this is really
+cool because now, any type of the form <code>Maybe something</code> is
+part of <code>YesNo</code> and it doesn’t matter what that
+<code>something</code> is.</p>
+<p>Previously, we defined a <code>Tree a</code> type, that represented a
+binary search tree. We can say an empty tree is false-ish and anything
+that’s not an empty tree is true-ish.</p>
+<pre class="haskell:hs"><code>instance YesNo (Tree a) where
     yesno EmptyTree = False
-    yesno _ = True
-</pre>
-<p>Can a traffic light be a yes or no value? Sure. If it's red, you stop. If it's green, you go. If it's yellow? Eh, I usually run the yellows because I live for adrenaline.</p>
-<pre name="code" class="haskell:hs">
-instance YesNo TrafficLight where
+    yesno _ = True</code></pre>
+<p>Can a traffic light be a yes or no value? Sure. If it’s red, you
+stop. If it’s green, you go. If it’s yellow? Eh, I usually run the
+yellows because I live for adrenaline.</p>
+<pre class="haskell:hs"><code>instance YesNo TrafficLight where
     yesno Red = False
-    yesno _ = True
-</pre>
-<p>Cool, now that we have some instances, let's go play!</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; yesno $ length []
+    yesno _ = True</code></pre>
+<p>Cool, now that we have some instances, let’s go play!</p>
+<pre class="haskell:hs"><code>ghci&gt; yesno $ length []
 False
-ghci&gt; yesno "haha"
+ghci&gt; yesno &quot;haha&quot;
 True
-ghci&gt; yesno ""
+ghci&gt; yesno &quot;&quot;
 False
 ghci&gt; yesno $ Just 0
 True
@@ -863,184 +1464,414 @@ False
 ghci&gt; yesno [0,0,0]
 True
 ghci&gt; :t yesno
-yesno :: (YesNo a) =&gt; a -&gt; Bool
-</pre>
-<p>Right, it works! Let's make a function that mimics the if statement, but it works with <span class="fixed">YesNo</span> values.</p>
-<pre name="code" class="haskell:hs">
-yesnoIf :: (YesNo y) =&gt; y -&gt; a -&gt; a -&gt; a
-yesnoIf yesnoVal yesResult noResult = if yesno yesnoVal then yesResult else noResult
-</pre>
-<p>Pretty straightforward. It takes a yes-no-ish value and two things. If the yes-no-ish value is more of a yes, it returns the first of the two things, otherwise it returns the second of them.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; yesnoIf [] "YEAH!" "NO!"
-"NO!"
-ghci&gt; yesnoIf [2,3,4] "YEAH!" "NO!"
-"YEAH!"
-ghci&gt; yesnoIf True "YEAH!" "NO!"
-"YEAH!"
-ghci&gt; yesnoIf (Just 500) "YEAH!" "NO!"
-"YEAH!"
-ghci&gt; yesnoIf Nothing "YEAH!" "NO!"
-"NO!"
-</pre>
-<a name="the-functor-typeclass"></a><h2>The Functor typeclass</h2>
-<p>So far, we've encountered a lot of the typeclasses in the standard library. We've played with <span class="fixed">Ord</span>, which is for stuff that can be ordered. We've palled around with <span class="fixed">Eq</span>, which is for things that can be equated. We've seen <span class="fixed">Show</span>, which presents an interface for types whose values can be displayed as strings. Our good friend <span class="fixed">Read</span> is there whenever we need to convert a string to a value of some type. And now, we're going to take a look at the <span class="label class">Functor</span> typeclass, which is basically for things that can be mapped over. You're probably thinking about lists now, since mapping over lists is such a dominant idiom in Haskell. And you're right, the list type is part of the <span class="fixed">Functor</span> typeclass.</p>
-<p>What better way to get to know the <span class="fixed">Functor</span> typeclass than to see how it's implemented? Let's take a peek.</p>
-<pre name="code" class="haskell:hs">
-class Functor f where
-    fmap :: (a -&gt; b) -&gt; f a -&gt; f b
-</pre>
-<img src="assets/images/making-our-own-types-and-typeclasses/functor.png" alt="I AM FUNCTOOOOR!!!" class="right" width="220" height="441">
-<p>Alright. We see that it defines one function, <span class="fixed">fmap</span>, and doesn't provide any default implementation for it. The type of <span class="fixed">fmap</span> is interesting. In the definitions of typeclasses so far, the type variable that played the role of the type in the typeclass was a concrete type, like the <span class="fixed">a</span> in <span class="fixed">(==) :: (Eq a) =&gt; a -&gt; a -&gt; Bool</span>. But now, the <span class="fixed">f</span> is not a concrete type (a type that a value can hold, like <span class="fixed">Int</span>, <span class="fixed">Bool</span> or <span class="fixed">Maybe String</span>), but a type constructor that takes one type parameter. A quick refresher example: <span class="fixed">Maybe Int</span> is a concrete type, but <span class="fixed">Maybe</span> is a type constructor that takes one type as the parameter. Anyway, we see that <span class="fixed">fmap</span> takes a function from one type to another and a functor applied with one type and returns a functor applied with another type.</p>
-<p>If this sounds a bit confusing, don't worry. All will be revealed soon when we check out a few examples. Hmm, this type declaration for <span class="fixed">fmap</span> reminds me of something. If you don't know what the type signature of <span class="fixed">map</span> is, it's: <span class="fixed">map :: (a -&gt; b) -&gt; [a] -&gt; [b]</span>.</p>
-<p>Ah, interesting! It takes a function from one type to another and a list of one type and returns a list of another type. My friends, I think we have ourselves a functor! In fact, <span class="fixed">map</span> is just a <span class="fixed">fmap</span> that works only on lists. Here's how the list is an instance of the <span class="fixed">Functor</span> typeclass.</p>
-<pre name="code" class="haskell:hs">
-instance Functor [] where
-    fmap = map
-</pre>
-<p>That's it! Notice how we didn't write <span class="fixed">instance Functor [a] where</span>, because from <span class="fixed">fmap :: (a -&gt; b) -&gt; f a -&gt; f b</span>, we see that the <span class="fixed">f</span> has to be a type constructor that takes one type. <span class="fixed">[a]</span> is already a concrete type (of a list with any type inside it), while <span class="fixed">[]</span> is a type constructor that takes one type and can produce types such as <span class="fixed">[Int]</span>, <span class="fixed">[String]</span> or even <span class="fixed">[[String]]</span>.</p>
-<p>Since for lists, <span class="fixed">fmap</span> is just <span class="fixed">map</span>, we get the same results when using them on lists.</p>
-<pre name="code" class="haskell:hs">
-map :: (a -&gt; b) -&gt; [a] -&gt; [b]
+yesno :: (YesNo a) =&gt; a -&gt; Bool</code></pre>
+<p>Right, it works! Let’s make a function that mimics the if statement,
+but it works with <code>YesNo</code> values.</p>
+<pre class="haskell:hs"><code>yesnoIf :: (YesNo y) =&gt; y -&gt; a -&gt; a -&gt; a
+yesnoIf yesnoVal yesResult noResult = if yesno yesnoVal then yesResult else noResult</code></pre>
+<p>Pretty straightforward. It takes a yes-no-ish value and two things.
+If the yes-no-ish value is more of a yes, it returns the first of the
+two things, otherwise it returns the second of them.</p>
+<pre class="haskell:hs"><code>ghci&gt; yesnoIf [] &quot;YEAH!&quot; &quot;NO!&quot;
+&quot;NO!&quot;
+ghci&gt; yesnoIf [2,3,4] &quot;YEAH!&quot; &quot;NO!&quot;
+&quot;YEAH!&quot;
+ghci&gt; yesnoIf True &quot;YEAH!&quot; &quot;NO!&quot;
+&quot;YEAH!&quot;
+ghci&gt; yesnoIf (Just 500) &quot;YEAH!&quot; &quot;NO!&quot;
+&quot;YEAH!&quot;
+ghci&gt; yesnoIf Nothing &quot;YEAH!&quot; &quot;NO!&quot;
+&quot;NO!&quot;</code></pre>
+<h2 id="the-functor-typeclass">The Functor typeclass</h2>
+<p>So far, we’ve encountered a lot of the typeclasses in the standard
+library. We’ve played with <code>Ord</code>, which is for stuff that can
+be ordered. We’ve palled around with <code>Eq</code>, which is for
+things that can be equated. We’ve seen <code>Show</code>, which presents
+an interface for types whose values can be displayed as strings. Our
+good friend <code>Read</code> is there whenever we need to convert a
+string to a value of some type. And now, we’re going to take a look at
+the <code class="label class">Functor</code> typeclass, which is
+basically for things that can be mapped over. You’re probably thinking
+about lists now, since mapping over lists is such a dominant idiom in
+Haskell. And you’re right, the list type is part of the
+<code>Functor</code> typeclass.</p>
+<p>What better way to get to know the <code>Functor</code> typeclass
+than to see how it’s implemented? Let’s take a peek.</p>
+<pre class="haskell:hs"><code>class Functor f where
+    fmap :: (a -&gt; b) -&gt; f a -&gt; f b</code></pre>
+<p><img
+src="assets/images/making-our-own-types-and-typeclasses/functor.png"
+class="right" width="220" height="441" alt="I AM FUNCTOOOOR!!!" /></p>
+<p>Alright. We see that it defines one function, <code>fmap</code>, and
+doesn’t provide any default implementation for it. The type of
+<code>fmap</code> is interesting. In the definitions of typeclasses so
+far, the type variable that played the role of the type in the typeclass
+was a concrete type, like the <code>a</code> in
+<code>(==) :: (Eq a) =&gt; a -&gt; a -&gt; Bool</code>. But now, the
+<code>f</code> is not a concrete type (a type that a value can hold,
+like <code>Int</code>, <code>Bool</code> or <code>Maybe String</code>),
+but a type constructor that takes one type parameter. A quick refresher
+example: <code>Maybe Int</code> is a concrete type, but
+<code>Maybe</code> is a type constructor that takes one type as the
+parameter. Anyway, we see that <code>fmap</code> takes a function from
+one type to another and a functor applied with one type and returns a
+functor applied with another type.</p>
+<p>If this sounds a bit confusing, don’t worry. All will be revealed
+soon when we check out a few examples. Hmm, this type declaration for
+<code>fmap</code> reminds me of something. If you don’t know what the
+type signature of <code>map</code> is, it’s:
+<code>map :: (a -&gt; b) -&gt; [a] -&gt; [b]</code>.</p>
+<p>Ah, interesting! It takes a function from one type to another and a
+list of one type and returns a list of another type. My friends, I think
+we have ourselves a functor! In fact, <code>map</code> is just a
+<code>fmap</code> that works only on lists. Here’s how the list is an
+instance of the <code>Functor</code> typeclass.</p>
+<pre class="haskell:hs"><code>instance Functor [] where
+    fmap = map</code></pre>
+<p>That’s it! Notice how we didn’t write
+<code>instance Functor [a] where</code>, because from
+<code>fmap :: (a -&gt; b) -&gt; f a -&gt; f b</code>, we see that the
+<code>f</code> has to be a type constructor that takes one type.
+<code>[a]</code> is already a concrete type (of a list with any type
+inside it), while <code>[]</code> is a type constructor that takes one
+type and can produce types such as <code>[Int]</code>,
+<code>[String]</code> or even <code>[[String]]</code>.</p>
+<p>Since for lists, <code>fmap</code> is just <code>map</code>, we get
+the same results when using them on lists.</p>
+<pre class="haskell:hs"><code>map :: (a -&gt; b) -&gt; [a] -&gt; [b]
 ghci&gt; fmap (*2) [1..3]
 [2,4,6]
 ghci&gt; map (*2) [1..3]
-[2,4,6]
-</pre>
-<p>What happens when we <span class="fixed">map</span> or <span class="fixed">fmap</span> over an empty list? Well, of course, we get an empty list. It just turns an empty list of type <span class="fixed">[a]</span> into an empty list of type <span class="fixed">[b]</span>.</p>
-<p>Types that can act like a box can be functors. You can think of a list as a box that has an infinite amount of little compartments and they can all be empty, one can be full and the others empty or a number of them can be full. So, what else has the properties of being like a box? For one, the <span class="fixed">Maybe a</span> type. In a way, it's like a box that can either hold nothing, in which case it has the value of <span class="fixed">Nothing</span>, or it can hold one item, like <span class="fixed">"HAHA"</span>, in which case it has a value of <span class="fixed">Just "HAHA"</span>. Here's how <span class="fixed">Maybe</span> is a functor.</p>
-<pre name="code" class="haskell:hs">
-instance Functor Maybe where
+[2,4,6]</code></pre>
+<p>What happens when we <code>map</code> or <code>fmap</code> over an
+empty list? Well, of course, we get an empty list. It just turns an
+empty list of type <code>[a]</code> into an empty list of type
+<code>[b]</code>.</p>
+<p>Types that can act like a box can be functors. You can think of a
+list as a box that has an infinite amount of little compartments and
+they can all be empty, one can be full and the others empty or a number
+of them can be full. So, what else has the properties of being like a
+box? For one, the <code>Maybe a</code> type. In a way, it’s like a box
+that can either hold nothing, in which case it has the value of
+<code>Nothing</code>, or it can hold one item, like <code>"HAHA"</code>,
+in which case it has a value of <code>Just "HAHA"</code>. Here’s how
+<code>Maybe</code> is a functor.</p>
+<pre class="haskell:hs"><code>instance Functor Maybe where
     fmap f (Just x) = Just (f x)
-    fmap f Nothing = Nothing
-</pre>
-<p>Again, notice how we wrote <span class="fixed">instance Functor Maybe where</span> instead of <span class="fixed">instance Functor (Maybe m) where</span>, like we did when we were dealing with <span class="fixed">Maybe</span> and <span class="fixed">YesNo</span>. <span class="fixed">Functor</span> wants a type constructor that takes one type and not a concrete type. If you mentally replace the <span class="fixed">f</span>s with <span class="fixed">Maybe</span>s, <span class="fixed">fmap</span> acts like a <span class="fixed">(a -&gt; b) -&gt; Maybe a -&gt; Maybe b</span> for this particular type, which looks OK. But if you replace <span class="fixed">f</span> with <span class="fixed">(Maybe m)</span>, then it would seem to act like a <span class="fixed">(a -&gt; b) -&gt; Maybe m a -&gt; Maybe m b</span>, which doesn't make any damn sense because <span class="fixed">Maybe</span> takes just one type parameter.</p>
-<p>Anyway, the <span class="fixed">fmap</span> implementation is pretty simple. If it's an empty value of <span class="fixed">Nothing</span>, then just return a <span class="fixed">Nothing</span>. If we map over an empty box, we get an empty box. It makes sense. Just like if we map over an empty list, we get back an empty list. If it's not an empty value, but rather a single value packed up in a <span class="fixed">Just</span>, then we apply the function on the contents of the <span class="fixed">Just</span>.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; fmap (++ " HEY GUYS IM INSIDE THE JUST") (Just "Something serious.")
-Just "Something serious. HEY GUYS IM INSIDE THE JUST"
-ghci&gt; fmap (++ " HEY GUYS IM INSIDE THE JUST") Nothing
+    fmap f Nothing = Nothing</code></pre>
+<p>Again, notice how we wrote <code>instance Functor Maybe where</code>
+instead of <code>instance Functor (Maybe m) where</code>, like we did
+when we were dealing with <code>Maybe</code> and <code>YesNo</code>.
+<code>Functor</code> wants a type constructor that takes one type and
+not a concrete type. If you mentally replace the <code>f</code>s with
+<code>Maybe</code>s, <code>fmap</code> acts like a
+<code>(a -&gt; b) -&gt; Maybe a -&gt; Maybe b</code> for this particular
+type, which looks OK. But if you replace <code>f</code> with
+<code>(Maybe m)</code>, then it would seem to act like a
+<code>(a -&gt; b) -&gt; Maybe m a -&gt; Maybe m b</code>, which doesn’t
+make any damn sense because <code>Maybe</code> takes just one type
+parameter.</p>
+<p>Anyway, the <code>fmap</code> implementation is pretty simple. If
+it’s an empty value of <code>Nothing</code>, then just return a
+<code>Nothing</code>. If we map over an empty box, we get an empty box.
+It makes sense. Just like if we map over an empty list, we get back an
+empty list. If it’s not an empty value, but rather a single value packed
+up in a <code>Just</code>, then we apply the function on the contents of
+the <code>Just</code>.</p>
+<pre class="haskell:hs"><code>ghci&gt; fmap (++ &quot; HEY GUYS IM INSIDE THE JUST&quot;) (Just &quot;Something serious.&quot;)
+Just &quot;Something serious. HEY GUYS IM INSIDE THE JUST&quot;
+ghci&gt; fmap (++ &quot; HEY GUYS IM INSIDE THE JUST&quot;) Nothing
 Nothing
 ghci&gt; fmap (*2) (Just 200)
 Just 400
 ghci&gt; fmap (*2) Nothing
-Nothing
-</pre>
-<p>Another thing that can be mapped over and made an instance of <span class="fixed">Functor</span> is our <span class="fixed">Tree a</span> type. It can be thought of as a box in a way (holds several or no values) and the <span class="fixed">Tree</span> type constructor takes exactly one type parameter. If you look at <span class="fixed">fmap</span> as if it were a function made only for <span class="fixed">Tree</span>, its type signature would look like <span class="fixed">(a -&gt; b) -&gt; Tree a -&gt; Tree b</span>. We're going to use recursion on this one. Mapping over an empty tree will produce an empty tree. Mapping over a non-empty tree will be a tree consisting of our function applied to the root value and its left and right subtrees will be the previous subtrees, only our function will be mapped over them.</p>
-<pre name="code" class="haskell:hs">
-instance Functor Tree where
+Nothing</code></pre>
+<p>Another thing that can be mapped over and made an instance of
+<code>Functor</code> is our <code>Tree a</code> type. It can be thought
+of as a box in a way (holds several or no values) and the
+<code>Tree</code> type constructor takes exactly one type parameter. If
+you look at <code>fmap</code> as if it were a function made only for
+<code>Tree</code>, its type signature would look like
+<code>(a -&gt; b) -&gt; Tree a -&gt; Tree b</code>. We’re going to use
+recursion on this one. Mapping over an empty tree will produce an empty
+tree. Mapping over a non-empty tree will be a tree consisting of our
+function applied to the root value and its left and right subtrees will
+be the previous subtrees, only our function will be mapped over
+them.</p>
+<pre class="haskell:hs"><code>instance Functor Tree where
     fmap f EmptyTree = EmptyTree
-    fmap f (Node x leftsub rightsub) = Node (f x) (fmap f leftsub) (fmap f rightsub)
-</pre>
-<pre name="code" class="haskell:hs">
-ghci&gt; fmap (*2) EmptyTree
+    fmap f (Node x leftsub rightsub) = Node (f x) (fmap f leftsub) (fmap f rightsub)</code></pre>
+<pre class="haskell:hs"><code>ghci&gt; fmap (*2) EmptyTree
 EmptyTree
 ghci&gt; fmap (*4) (foldr treeInsert EmptyTree [5,7,3,2,1,7])
-Node 28 (Node 4 EmptyTree (Node 8 EmptyTree (Node 12 EmptyTree (Node 20 EmptyTree EmptyTree)))) EmptyTree
-</pre>
-<p>Nice! Now how about <span class="fixed">Either a b</span>? Can this be made a functor? The <span class="fixed">Functor</span> typeclass wants a type constructor that takes only one type parameter but <span class="fixed">Either</span> takes two. Hmmm! I know, we'll partially apply <span class="fixed">Either</span> by feeding it only one parameter so that it has one free parameter. Here's how <span class="fixed">Either a</span> is a functor in the standard libraries:</p>
-<pre name="code" class="haskell:hs">
-instance Functor (Either a) where
+Node 28 (Node 4 EmptyTree (Node 8 EmptyTree (Node 12 EmptyTree (Node 20 EmptyTree EmptyTree)))) EmptyTree</code></pre>
+<p>Nice! Now how about <code>Either a b</code>? Can this be made a
+functor? The <code>Functor</code> typeclass wants a type constructor
+that takes only one type parameter but <code>Either</code> takes two.
+Hmmm! I know, we’ll partially apply <code>Either</code> by feeding it
+only one parameter so that it has one free parameter. Here’s how
+<code>Either a</code> is a functor in the standard libraries:</p>
+<pre class="haskell:hs"><code>instance Functor (Either a) where
     fmap f (Right x) = Right (f x)
-    fmap f (Left x) = Left x
-</pre>
-<p>Well well, what did we do here? You can see how we made <span class="fixed">Either a</span> an instance instead of just <span class="fixed">Either</span>. That's because <span class="fixed">Either a</span> is a type constructor that takes one parameter, whereas <span class="fixed">Either</span> takes two. If <span class="fixed">fmap</span> was specifically for <span class="fixed">Either a</span>, the type signature would then be <span class="fixed">(b -&gt; c) -&gt; Either a b -&gt; Either a c</span> because that's the same as <span class="fixed">(b -&gt; c) -&gt; (Either a) b -&gt; (Either a) c</span>. In the implementation, we mapped in the case of a <span class="fixed">Right</span> value constructor, but we didn't in the case of a <span class="fixed">Left</span>. Why is that? Well, if we look back at how the <span class="fixed">Either a b</span> type is defined, it's kind of like:</p>
-<pre name="code" class="haskell:hs">
-data Either a b = Left a | Right b
-</pre>
-<p>Well, if we wanted to map one function over both of them, <span class="fixed">a</span> and <span class="fixed">b</span> would have to be the same type. I mean, if we tried to map a function that takes a string and returns a string and the <span class="fixed">b</span> was a string but the <span class="fixed">a</span> was a number, that wouldn't really work out. Also, from seeing what <span class="fixed">fmap</span>'s type would be if it operated only on <span class="fixed">Either</span> values, we see that the first parameter has to remain the same while the second one can change and the first parameter is actualized by the <span class="fixed">Left</span> value constructor.</p>
-<p>This also goes nicely with our box analogy if we think of the <span class="fixed">Left</span> part as sort of an empty box with an error message written on the side telling us why it's empty.</p>
-<p>Maps from <span class="fixed">Data.Map</span> can also be made a functor because they hold values (or not!). In the case of <span class="fixed">Map k v</span>, <span class="fixed">fmap</span> will map a function <span class="fixed">v -&gt; v'</span> over a map of type <span class="fixed">Map k v</span> and return a map of type <span class="fixed">Map k v'</span>. </p><div class="hintbox">Note, the <span class="fixed">'</span> has no special meaning in types just like it doesn't have special meaning when naming values. It's used to denote things that are similar, only slightly changed.</div>
-<p>Try figuring out how <span class="fixed">Map k</span> is made an instance of <span class="fixed">Functor</span> by yourself!</p>
-<p>With the <span class="fixed">Functor</span> typeclass, we've seen how typeclasses can represent pretty cool higher-order concepts. We've also had some more practice with partially applying types and making instances. In one of the next chapters, we'll also take a look at some laws that apply for functors.</p>
-<div class="hintbox"><em>Just one more thing!</em> Functors should obey some laws so that they may have some properties that we can depend on and not think about too much. If we use <span class="fixed">fmap (+1)</span> over the list <span class="fixed">[1,2,3,4]</span>, we expect the result to be <span class="fixed">[2,3,4,5]</span> and not its reverse, <span class="fixed">[5,4,3,2]</span>. If we use <span class="fixed">fmap (\a -&gt; a)</span> (the identity function, which just returns its parameter) over some list, we expect to get back the same list as a result. For example, if we gave the wrong functor instance to our <span class="fixed">Tree</span> type, using <span class="fixed">fmap</span> over a tree where the left subtree of a node only has elements that are smaller than the node and the right subtree only has nodes that are larger than the node might produce a tree where that's not the case. We'll go over the functor laws in more detail in one of the next chapters.</div>
-<a name="kinds-and-some-type-foo"></a><h2>Kinds and some type-foo</h2>
-<img src="assets/images/making-our-own-types-and-typeclasses/typefoo.png" alt="TYPE FOO MASTER" class="right" width="287" height="400">
-<p>Type constructors take other types as parameters to eventually produce concrete types. That kind of reminds me of functions, which take values as parameters to produce values. We've seen that type constructors can be partially applied (<span class="fixed">Either String</span> is a type that takes one type and produces a concrete type, like <span class="fixed">Either String Int</span>), just like functions can. This is all very interesting indeed. In this section, we'll take a look at formally defining how types are applied to type constructors, just like we took a look at formally defining how values are applied to functions by using type declarations. <em>You don't really have to read this section to continue on your magical Haskell quest</em> and if you don't understand it, don't worry about it. However, getting this will give you a very thorough understanding of the type system.</p>
-<p>So, values like <span class="fixed">3</span>, <span class="fixed">"YEAH"</span> or <span class="fixed">takeWhile</span> (functions are also values, because we can pass them around and such) each have their own type. Types are little labels that values carry so that we can reason about the values. But types have their own little labels, called <em>kinds</em>. A kind is more or less the type of a type. This may sound a bit weird and confusing, but it's actually a really cool concept.</p>
-<p>What are kinds and what are they good for? Well, let's examine the kind of a type by using the <span class="fixed">:k</span> command in GHCI.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; :k Int
-Int :: *
-</pre>
-<p>A star? How quaint. What does that mean? A <span class="fixed">*</span> means that the type is a concrete type. A concrete type is a type that doesn't take any type parameters and values can only have types that are concrete types. If I had to read <span class="fixed">*</span> out loud (I haven't had to do that so far), I'd say <i>star</i> or just <i>type</i>.</p>
-<p>Okay, now let's see what the kind of <span class="fixed">Maybe</span> is.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; :k Maybe
-Maybe :: * -&gt; *
-</pre>
-<p>The <span class="fixed">Maybe</span> type constructor takes one concrete type (like <span class="fixed">Int</span>) and then returns a concrete type like <span class="fixed">Maybe Int</span>. And that's what this kind tells us. Just like <span class="fixed">Int -&gt; Int</span> means that a function takes an <span class="fixed">Int</span> and returns an <span class="fixed">Int</span>, <span class="fixed">* -&gt; *</span> means that the type constructor takes one concrete type and returns a concrete type. Let's apply the type parameter to <span class="fixed">Maybe</span> and see what the kind of that type is.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; :k Maybe Int
-Maybe Int :: *
-</pre>
-<p>Just like I expected! We applied the type parameter to <span class="fixed">Maybe</span> and got back a concrete type (that's what <span class="fixed">* -&gt; *</span> means). A parallel (although not equivalent, types and kinds are two different things) to this is if we do <span class="fixed">:t isUpper</span> and <span class="fixed">:t isUpper 'A'</span>. <span class="fixed">isUpper</span> has a type of <span class="fixed">Char -&gt; Bool</span> and <span class="fixed">isUpper 'A'</span> has a type of <span class="fixed">Bool</span>, because its value is basically <span class="fixed">True</span>. Both those types, however, have a kind of <span class="fixed">*</span>.</p>
-<p>We used <span class="fixed">:k</span> on a type to get its kind, just like we can use <span class="fixed">:t</span> on a value to get its type. Like we said, types are the labels of values and kinds are the labels of types and there are parallels between the two.</p>
-<p>Let's look at another kind.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; :k Either
-Either :: * -&gt; * -&gt; *
-</pre>
-<p>Aha, this tells us that <span class="fixed">Either</span> takes two concrete types as type parameters to produce a concrete type. It also looks kind of like a type declaration of a function that takes two values and returns something. Type constructors are curried (just like functions), so we can partially apply them.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; :k Either String
+    fmap f (Left x) = Left x</code></pre>
+<p>Well well, what did we do here? You can see how we made
+<code>Either a</code> an instance instead of just <code>Either</code>.
+That’s because <code>Either a</code> is a type constructor that takes
+one parameter, whereas <code>Either</code> takes two. If
+<code>fmap</code> was specifically for <code>Either a</code>, the type
+signature would then be
+<code>(b -&gt; c) -&gt; Either a b -&gt; Either a c</code> because
+that’s the same as
+<code>(b -&gt; c) -&gt; (Either a) b -&gt; (Either a) c</code>. In the
+implementation, we mapped in the case of a <code>Right</code> value
+constructor, but we didn’t in the case of a <code>Left</code>. Why is
+that? Well, if we look back at how the <code>Either a b</code> type is
+defined, it’s kind of like:</p>
+<pre class="haskell:hs"><code>data Either a b = Left a | Right b</code></pre>
+<p>Well, if we wanted to map one function over both of them,
+<code>a</code> and <code>b</code> would have to be the same type. I
+mean, if we tried to map a function that takes a string and returns a
+string and the <code>b</code> was a string but the <code>a</code> was a
+number, that wouldn’t really work out. Also, from seeing what
+<code>fmap</code>’s type would be if it operated only on
+<code>Either</code> values, we see that the first parameter has to
+remain the same while the second one can change and the first parameter
+is actualized by the <code>Left</code> value constructor.</p>
+<p>This also goes nicely with our box analogy if we think of the
+<code>Left</code> part as sort of an empty box with an error message
+written on the side telling us why it’s empty.</p>
+<p>Maps from <code>Data.Map</code> can also be made a functor because
+they hold values (or not!). In the case of <code>Map k v</code>,
+<code>fmap</code> will map a function <code>v -&gt; v'</code> over a map
+of type <code>Map k v</code> and return a map of type
+<code>Map k v'</code>.</p>
+<div class="hintbox">
+<p>Note, the <code>'</code> has no special meaning in types just like it
+doesn’t have special meaning when naming values. It’s used to denote
+things that are similar, only slightly changed.</p>
+</div>
+<p>Try figuring out how <code>Map k</code> is made an instance of
+<code>Functor</code> by yourself!</p>
+<p>With the <code>Functor</code> typeclass, we’ve seen how typeclasses
+can represent pretty cool higher-order concepts. We’ve also had some
+more practice with partially applying types and making instances. In one
+of the next chapters, we’ll also take a look at some laws that apply for
+functors.</p>
+<div class="hintbox">
+<p><strong>Just one more thing!</strong> Functors should obey some laws
+so that they may have some properties that we can depend on and not
+think about too much. If we use <code>fmap (+1)</code> over the list
+<code>[1,2,3,4]</code>, we expect the result to be
+<code>[2,3,4,5]</code> and not its reverse, <code>[5,4,3,2]</code>. If
+we use <code>fmap (\a -&gt; a)</code> (the identity function, which just
+returns its parameter) over some list, we expect to get back the same
+list as a result. For example, if we gave the wrong functor instance to
+our <code>Tree</code> type, using <code>fmap</code> over a tree where
+the left subtree of a node only has elements that are smaller than the
+node and the right subtree only has nodes that are larger than the node
+might produce a tree where that’s not the case. We’ll go over the
+functor laws in more detail in one of the next chapters.</p>
+</div>
+<h2 id="kinds-and-some-type-foo">Kinds and some type-foo</h2>
+<p><img
+src="assets/images/making-our-own-types-and-typeclasses/typefoo.png"
+class="right" width="287" height="400" alt="TYPE FOO MASTER" /></p>
+<p>Type constructors take other types as parameters to eventually
+produce concrete types. That kind of reminds me of functions, which take
+values as parameters to produce values. We’ve seen that type
+constructors can be partially applied (<code>Either String</code> is a
+type that takes one type and produces a concrete type, like
+<code>Either String Int</code>), just like functions can. This is all
+very interesting indeed. In this section, we’ll take a look at formally
+defining how types are applied to type constructors, just like we took a
+look at formally defining how values are applied to functions by using
+type declarations. <strong>You don’t really have to read this section to
+continue on your magical Haskell quest</strong> and if you don’t
+understand it, don’t worry about it. However, getting this will give you
+a very thorough understanding of the type system.</p>
+<p>So, values like <code>3</code>, <code>"YEAH"</code> or
+<code>takeWhile</code> (functions are also values, because we can pass
+them around and such) each have their own type. Types are little labels
+that values carry so that we can reason about the values. But types have
+their own little labels, called <strong>kinds</strong>. A kind is more
+or less the type of a type. This may sound a bit weird and confusing,
+but it’s actually a really cool concept.</p>
+<p>What are kinds and what are they good for? Well, let’s examine the
+kind of a type by using the <code>:k</code> command in GHCI.</p>
+<pre class="haskell:hs"><code>ghci&gt; :k Int
+Int :: *</code></pre>
+<p>A star? How quaint. What does that mean? A <code>*</code> means that
+the type is a concrete type. A concrete type is a type that doesn’t take
+any type parameters and values can only have types that are concrete
+types. If I had to read <code>*</code> out loud (I haven’t had to do
+that so far), I’d say <em>star</em> or just <em>type</em>.</p>
+<p>Okay, now let’s see what the kind of <code>Maybe</code> is.</p>
+<pre class="haskell:hs"><code>ghci&gt; :k Maybe
+Maybe :: * -&gt; *</code></pre>
+<p>The <code>Maybe</code> type constructor takes one concrete type (like
+<code>Int</code>) and then returns a concrete type like
+<code>Maybe Int</code>. And that’s what this kind tells us. Just like
+<code>Int -&gt; Int</code> means that a function takes an
+<code>Int</code> and returns an <code>Int</code>, <code>* -&gt; *</code>
+means that the type constructor takes one concrete type and returns a
+concrete type. Let’s apply the type parameter to <code>Maybe</code> and
+see what the kind of that type is.</p>
+<pre class="haskell:hs"><code>ghci&gt; :k Maybe Int
+Maybe Int :: *</code></pre>
+<p>Just like I expected! We applied the type parameter to
+<code>Maybe</code> and got back a concrete type (that’s what
+<code>* -&gt; *</code> means). A parallel (although not equivalent,
+types and kinds are two different things) to this is if we do
+<code>:t isUpper</code> and <code>:t isUpper 'A'</code>.
+<code>isUpper</code> has a type of <code>Char -&gt; Bool</code> and
+<code>isUpper 'A'</code> has a type of <code>Bool</code>, because its
+value is basically <code>True</code>. Both those types, however, have a
+kind of <code>*</code>.</p>
+<p>We used <code>:k</code> on a type to get its kind, just like we can
+use <code>:t</code> on a value to get its type. Like we said, types are
+the labels of values and kinds are the labels of types and there are
+parallels between the two.</p>
+<p>Let’s look at another kind.</p>
+<pre class="haskell:hs"><code>ghci&gt; :k Either
+Either :: * -&gt; * -&gt; *</code></pre>
+<p>Aha, this tells us that <code>Either</code> takes two concrete types
+as type parameters to produce a concrete type. It also looks kind of
+like a type declaration of a function that takes two values and returns
+something. Type constructors are curried (just like functions), so we
+can partially apply them.</p>
+<pre class="haskell:hs"><code>ghci&gt; :k Either String
 Either String :: * -&gt; *
 ghci&gt; :k Either String Int
-Either String Int :: *
-</pre>
-<p>When we wanted to make <span class="fixed">Either</span> a part of the <span class="fixed">Functor</span> typeclass, we had to partially apply it because <span class="fixed">Functor</span> wants types that take only one parameter while <span class="fixed">Either</span> takes two. In other words, <span class="fixed">Functor</span> wants types of kind <span class="fixed">* -&gt; *</span> and so we had to partially apply <span class="fixed">Either</span> to get a type of kind <span class="fixed">* -&gt; *</span> instead of its original kind <span class="fixed">* -&gt; * -&gt; *</span>. If we look at the definition of <span class="fixed">Functor</span> again</p>
-<pre name="code" class="haskell:hs">
-class Functor f where
-    fmap :: (a -&gt; b) -&gt; f a -&gt; f b
-</pre>
-<p>we see that the <span class="fixed">f</span> type variable is used as a type that takes one concrete type to produce a concrete type. We know it has to produce a concrete type because it's used as the type of a value in a function. And from that, we can deduce that types that want to be friends with <span class="fixed">Functor</span> have to be of kind <span class="fixed">* -&gt; *</span>.</p>
-<p>Now, let's do some type-foo. Take a look at this typeclass that I'm just going to make up right now:</p>
-<pre name="code" class="haskell:hs">
-class Tofu t where
-    tofu :: j a -&gt; t a j
-</pre>
-<p>Man, that looks weird. How would we make a type that could be an instance of that strange typeclass? Well, let's look at what its kind would have to be. Because <span class="fixed">j a</span> is used as the type of a value that the <span class="fixed">tofu</span> function takes as its parameter, <span class="fixed">j a</span> has to have a kind of <span class="fixed">*</span>. We assume <span class="fixed">*</span> for <span class="fixed">a</span> and so we can infer that <span class="fixed">j</span> has to have a kind of <span class="fixed">* -&gt; *</span>. We see that <span class="fixed">t</span> has to produce a concrete value too and that it takes two types. And knowing that <span class="fixed">a</span> has a kind of <span class="fixed">*</span> and <span class="fixed">j</span> has a kind of <span class="fixed">* -&gt; *</span>, we infer that <span class="fixed">t</span> has to have a kind of <span class="fixed">* -&gt; (* -&gt; *) -&gt; *</span>. So it takes a concrete type (<span class="fixed">a</span>), a type constructor that takes one concrete type (<span class="fixed">j</span>) and produces a concrete type. Wow.</p>
-<p>OK, so let's make a type with a kind of <span class="fixed">* -&gt; (* -&gt; *) -&gt; *</span>. Here's one way of going about it.</p>
-<pre name="code" class="haskell:hs">
-data Frank a b  = Frank {frankField :: b a} deriving (Show)
-</pre>
-<p>How do we know this type has a kind of <span class="fixed">* -&gt; (* -&gt; *) - &gt; *</span>? Well, fields in ADTs are made to hold values, so they must be of kind <span class="fixed">*</span>, obviously. We assume <span class="fixed">*</span> for <span class="fixed">a</span>, which means that <span class="fixed">b</span> takes one type parameter and so its kind is <span class="fixed">* -&gt; *</span>. Now we know the kinds of both <span class="fixed">a</span> and <span class="fixed">b</span> and because they're parameters for <span class="fixed">Frank</span>, we see that <span class="fixed">Frank</span> has a kind of <span class="fixed">* -&gt; (* -&gt; *) -&gt; *</span> The first <span class="fixed">*</span> represents <span class="fixed">a</span> and the <span class="fixed">(* -&gt; *)</span> represents <span class="fixed">b</span>. Let's make some <span class="fixed">Frank</span> values and check out their types.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; :t Frank {frankField = Just "HAHA"}
-Frank {frankField = Just "HAHA"} :: Frank [Char] Maybe
-ghci&gt; :t Frank {frankField = Node 'a' EmptyTree EmptyTree}
-Frank {frankField = Node 'a' EmptyTree EmptyTree} :: Frank Char Tree
-ghci&gt; :t Frank {frankField = "YES"}
-Frank {frankField = "YES"} :: Frank Char []
-</pre>
-<p>Hmm. Because <span class="fixed">frankField</span> has a type of form <span class="fixed">a b</span>, its values must have types that are of a similar form as well. So they can be <span class="fixed">Just "HAHA"</span>, which has a type of <span class="fixed">Maybe [Char]</span> or it can have a value of <span class="fixed">['Y','E','S']</span>, which has a type of <span class="fixed">[Char]</span> (if we used our own list type for this, it would have a type of <span class="fixed">List Char</span>). And we see that the types of the <span class="fixed">Frank</span> values correspond with the kind for <span class="fixed">Frank</span>. <span class="fixed">[Char]</span> has a kind of <span class="fixed">*</span> and <span class="fixed">Maybe</span> has a kind of <span class="fixed">* -&gt; *</span>. Because in order to have a value, it has to be a concrete type and thus has to be fully applied, every value of <span class="fixed">Frank blah blaah</span> has a kind of <span class="fixed">*</span>.</p>
-<p>Making <span class="fixed">Frank</span> an instance of <span class="fixed">Tofu</span> is pretty simple. We see that <span class="fixed">tofu</span> takes a <span class="fixed">j a</span> (so an example type of that form would be <span class="fixed">Maybe Int</span>) and returns a <span class="fixed">t a j</span>. So if we replace <span class="fixed">Frank</span> with <span class="fixed">j</span>, the result type would be <span class="fixed">Frank Int Maybe</span>.</p>
-<pre name="code" class="haskell:hs">
-instance Tofu Frank where
-    tofu x = Frank x
-</pre>
-<pre name="code" class="haskell:hs">
-ghci&gt; tofu (Just 'a') :: Frank Char Maybe
-Frank {frankField = Just 'a'}
-ghci&gt; tofu ["HELLO"] :: Frank [Char] []
-Frank {frankField = ["HELLO"]}
-</pre>
-<p>Not very useful, but we did flex our type muscles. Let's do some more type-foo. We have this data type:</p>
-<pre name="code" class="haskell:hs">
-data Barry t k p = Barry { yabba :: p, dabba :: t k }
-</pre>
-<p>And now we want to make it an instance of <span class="fixed">Functor</span>. <span class="fixed">Functor</span> wants types of kind <span class="fixed">* -&gt; *</span> but <span class="fixed">Barry</span> doesn't look like it has that kind. What is the kind of <span class="fixed">Barry</span>? Well, we see it takes three type parameters, so it's going to be <span class="fixed">something -&gt; something -&gt; something -&gt; *</span>. It's safe to say that <span class="fixed">p</span> is a concrete type and thus has a kind of <span class="fixed">*</span>. For <span class="fixed">k</span>, we assume <span class="fixed">*</span> and so by extension, <span class="fixed">t</span> has a kind of <span class="fixed">* -&gt; *</span>. Now let's just replace those kinds with the <i>somethings</i> that we used as placeholders and we see it has a kind of <span class="fixed">(* -&gt; *) -&gt; * -&gt; * -&gt; *</span>. Let's check that with GHCI.</p>
-<pre name="code" class="haskell:hs">
-ghci&gt; :k Barry
-Barry :: (* -&gt; *) -&gt; * -&gt; * -&gt; *
-</pre>
-<p>Ah, we were right. How satisfying. Now, to make this type a part of <span class="fixed">Functor</span> we have to partially apply the first two type parameters so that we're left with <span class="fixed">* -&gt; *</span>. That means that the start of the instance declaration will be: <span class="fixed">instance Functor (Barry a b) where</span>. If we look at <span class="fixed">fmap</span> as if it was made specifically for <span class="fixed">Barry</span>, it would have a type of <span class="fixed">fmap :: (a -&gt; b) -&gt; Barry c d a -&gt; Barry c d b</span>, because we just replace the <span class="fixed">Functor</span>'s <span class="fixed">f</span> with <span class="fixed">Barry c d</span>. The third type parameter from <span class="fixed">Barry</span> will have to change and we see that it's conveniently in its own field.</p>
-<pre name="code" class="haskell:hs">
-instance Functor (Barry a b) where
-    fmap f (Barry {yabba = x, dabba = y}) = Barry {yabba = f x, dabba = y}
-</pre>
-<p>There we go! We just mapped the <span class="fixed">f</span> over the first field.</p>
-<p>In this section, we took a good look at how type parameters work and kind of formalized them with kinds, just like we formalized function parameters with type declarations. We saw that there are interesting parallels between functions and type constructors. They are, however, two completely different things. When working on real Haskell, you usually won't have to mess with kinds and do kind inference by hand like we did now. Usually, you just have to partially apply your own type to <span class="fixed">* -&gt; *</span> or <span class="fixed">*</span> when making it an instance of one of the standard typeclasses, but it's good to know how and why that actually works. It's also interesting to see that types have little types of their own. Again, you don't really have to understand everything we did here to read on, but if you understand how kinds work, chances are that you have a very solid grasp of Haskell's type system.</p>
+Either String Int :: *</code></pre>
+<p>When we wanted to make <code>Either</code> a part of the
+<code>Functor</code> typeclass, we had to partially apply it because
+<code>Functor</code> wants types that take only one parameter while
+<code>Either</code> takes two. In other words, <code>Functor</code>
+wants types of kind <code>* -&gt; *</code> and so we had to partially
+apply <code>Either</code> to get a type of kind <code>* -&gt; *</code>
+instead of its original kind <code>* -&gt; * -&gt; *</code>. If we look
+at the definition of <code>Functor</code> again</p>
+<pre class="haskell:hs"><code>class Functor f where
+    fmap :: (a -&gt; b) -&gt; f a -&gt; f b</code></pre>
+<p>we see that the <code>f</code> type variable is used as a type that
+takes one concrete type to produce a concrete type. We know it has to
+produce a concrete type because it’s used as the type of a value in a
+function. And from that, we can deduce that types that want to be
+friends with <code>Functor</code> have to be of kind
+<code>* -&gt; *</code>.</p>
+<p>Now, let’s do some type-foo. Take a look at this typeclass that I’m
+just going to make up right now:</p>
+<pre class="haskell:hs"><code>class Tofu t where
+    tofu :: j a -&gt; t a j</code></pre>
+<p>Man, that looks weird. How would we make a type that could be an
+instance of that strange typeclass? Well, let’s look at what its kind
+would have to be. Because <code>j a</code> is used as the type of a
+value that the <code>tofu</code> function takes as its parameter,
+<code>j a</code> has to have a kind of <code>*</code>. We assume
+<code>*</code> for <code>a</code> and so we can infer that
+<code>j</code> has to have a kind of <code>* -&gt; *</code>. We see that
+<code>t</code> has to produce a concrete value too and that it takes two
+types. And knowing that <code>a</code> has a kind of <code>*</code> and
+<code>j</code> has a kind of <code>* -&gt; *</code>, we infer that
+<code>t</code> has to have a kind of
+<code>* -&gt; (* -&gt; *) -&gt; *</code>. So it takes a concrete type
+(<code>a</code>), a type constructor that takes one concrete type
+(<code>j</code>) and produces a concrete type. Wow.</p>
+<p>OK, so let’s make a type with a kind of
+<code>* -&gt; (* -&gt; *) -&gt; *</code>. Here’s one way of going about
+it.</p>
+<pre class="haskell:hs"><code>data Frank a b  = Frank {frankField :: b a} deriving (Show)</code></pre>
+<p>How do we know this type has a kind of
+<code>* -&gt; (* -&gt; *) - &gt; *</code>? Well, fields in ADTs are made
+to hold values, so they must be of kind <code>*</code>, obviously. We
+assume <code>*</code> for <code>a</code>, which means that
+<code>b</code> takes one type parameter and so its kind is
+<code>* -&gt; *</code>. Now we know the kinds of both <code>a</code> and
+<code>b</code> and because they’re parameters for <code>Frank</code>, we
+see that <code>Frank</code> has a kind of
+<code>* -&gt; (* -&gt; *) -&gt; *</code> The first <code>*</code>
+represents <code>a</code> and the <code>(* -&gt; *)</code> represents
+<code>b</code>. Let’s make some <code>Frank</code> values and check out
+their types.</p>
+<pre class="haskell:hs"><code>ghci&gt; :t Frank {frankField = Just &quot;HAHA&quot;}
+Frank {frankField = Just &quot;HAHA&quot;} :: Frank [Char] Maybe
+ghci&gt; :t Frank {frankField = Node &#39;a&#39; EmptyTree EmptyTree}
+Frank {frankField = Node &#39;a&#39; EmptyTree EmptyTree} :: Frank Char Tree
+ghci&gt; :t Frank {frankField = &quot;YES&quot;}
+Frank {frankField = &quot;YES&quot;} :: Frank Char []</code></pre>
+<p>Hmm. Because <code>frankField</code> has a type of form
+<code>a b</code>, its values must have types that are of a similar form
+as well. So they can be <code>Just "HAHA"</code>, which has a type of
+<code>Maybe [Char]</code> or it can have a value of
+<code>['Y','E','S']</code>, which has a type of <code>[Char]</code> (if
+we used our own list type for this, it would have a type of
+<code>List Char</code>). And we see that the types of the
+<code>Frank</code> values correspond with the kind for
+<code>Frank</code>. <code>[Char]</code> has a kind of <code>*</code> and
+<code>Maybe</code> has a kind of <code>* -&gt; *</code>. Because in
+order to have a value, it has to be a concrete type and thus has to be
+fully applied, every value of <code>Frank blah blaah</code> has a kind
+of <code>*</code>.</p>
+<p>Making <code>Frank</code> an instance of <code>Tofu</code> is pretty
+simple. We see that <code>tofu</code> takes a <code>j a</code> (so an
+example type of that form would be <code>Maybe Int</code>) and returns a
+<code>t a j</code>. So if we replace <code>Frank</code> with
+<code>j</code>, the result type would be
+<code>Frank Int Maybe</code>.</p>
+<pre class="haskell:hs"><code>instance Tofu Frank where
+    tofu x = Frank x</code></pre>
+<pre class="haskell:hs"><code>ghci&gt; tofu (Just &#39;a&#39;) :: Frank Char Maybe
+Frank {frankField = Just &#39;a&#39;}
+ghci&gt; tofu [&quot;HELLO&quot;] :: Frank [Char] []
+Frank {frankField = [&quot;HELLO&quot;]}</code></pre>
+<p>Not very useful, but we did flex our type muscles. Let’s do some more
+type-foo. We have this data type:</p>
+<pre class="haskell:hs"><code>data Barry t k p = Barry { yabba :: p, dabba :: t k }</code></pre>
+<p>And now we want to make it an instance of <code>Functor</code>.
+<code>Functor</code> wants types of kind <code>* -&gt; *</code> but
+<code>Barry</code> doesn’t look like it has that kind. What is the kind
+of <code>Barry</code>? Well, we see it takes three type parameters, so
+it’s going to be
+<code>something -&gt; something -&gt; something -&gt; *</code>. It’s
+safe to say that <code>p</code> is a concrete type and thus has a kind
+of <code>*</code>. For <code>k</code>, we assume <code>*</code> and so
+by extension, <code>t</code> has a kind of <code>* -&gt; *</code>. Now
+let’s just replace those kinds with the <em>somethings</em> that we used
+as placeholders and we see it has a kind of
+<code>(* -&gt; *) -&gt; * -&gt; * -&gt; *</code>. Let’s check that with
+GHCI.</p>
+<pre class="haskell:hs"><code>ghci&gt; :k Barry
+Barry :: (* -&gt; *) -&gt; * -&gt; * -&gt; *</code></pre>
+<p>Ah, we were right. How satisfying. Now, to make this type a part of
+<code>Functor</code> we have to partially apply the first two type
+parameters so that we’re left with <code>* -&gt; *</code>. That means
+that the start of the instance declaration will be:
+<code>instance Functor (Barry a b) where</code>. If we look at
+<code>fmap</code> as if it was made specifically for <code>Barry</code>,
+it would have a type of
+<code>fmap :: (a -&gt; b) -&gt; Barry c d a -&gt; Barry c d b</code>,
+because we just replace the <code>Functor</code>’s <code>f</code> with
+<code>Barry c d</code>. The third type parameter from <code>Barry</code>
+will have to change and we see that it’s conveniently in its own
+field.</p>
+<pre class="haskell:hs"><code>instance Functor (Barry a b) where
+    fmap f (Barry {yabba = x, dabba = y}) = Barry {yabba = f x, dabba = y}</code></pre>
+<p>There we go! We just mapped the <code>f</code> over the first
+field.</p>
+<p>In this section, we took a good look at how type parameters work and
+kind of formalized them with kinds, just like we formalized function
+parameters with type declarations. We saw that there are interesting
+parallels between functions and type constructors. They are, however,
+two completely different things. When working on real Haskell, you
+usually won’t have to mess with kinds and do kind inference by hand like
+we did now. Usually, you just have to partially apply your own type to
+<code>* -&gt; *</code> or <code>*</code> when making it an instance of
+one of the standard typeclasses, but it’s good to know how and why that
+actually works. It’s also interesting to see that types have little
+types of their own. Again, you don’t really have to understand
+everything we did here to read on, but if you understand how kinds work,
+chances are that you have a very solid grasp of Haskell’s type
+system.</p>
                 <div class="footdiv">
                 <ul>
                     <li style="text-align:left">

--- a/docs/modules.html
+++ b/docs/modules.html
@@ -31,727 +31,1063 @@
                                             </li>
                 </ul>
             </div>
-        <h1>Modules</h1>
-<a name="loading-modules"></a><h2>Loading modules</h2>
-<img src="assets/images/modules/modules.png" alt="modules" class="right" width="230" height="162">
-<p>A Haskell module is a collection of related functions, types and typeclasses. A Haskell program is a collection of modules where the main module loads up the other modules and then uses the functions defined in them to do something. Having code split up into several modules has quite a lot of advantages. If a module is generic enough, the functions it exports can be used in a multitude of different programs. If your own code is separated into self-contained modules which don't rely on each other too much (we also say they are loosely coupled), you can reuse them later on. It makes the whole deal of writing code more manageable by having it split into several parts, each of which has some sort of purpose.</p>
-<p>The Haskell standard library is split into modules, each of them contains functions and types that are somehow related and serve some common purpose. There's a module for manipulating lists, a module for concurrent programming, a module for dealing with complex numbers, etc. All the functions, types and typeclasses that we've dealt with so far were part of the <span class="fixed">Prelude</span> module, which is imported by default. In this chapter, we're going to examine a few useful modules and the functions that they have. But first, we're going to see how to import modules.</p>
-<p>The syntax for importing modules in a Haskell script is <span class="fixed">import &lt;module name&gt;</span>. This must be done before defining any functions, so imports are usually done at the top of the file. One script can, of course, import several modules. Just put each import statement into a separate line. Let's import the <span class="fixed">Data.List</span> module, which has a bunch of useful functions for working with lists and use a function that it exports to create a function that tells us how many unique elements a list has.</p>
-<pre name="code" class="haskell:hs">
-import Data.List
+<h1 id="modules">Modules</h1>
+<h2 id="loading-modules">Loading modules</h2>
+<p><img src="assets/images/modules/modules.png" class="right"
+width="230" height="162" alt="modules" /></p>
+<p>A Haskell module is a collection of related functions, types and
+typeclasses. A Haskell program is a collection of modules where the main
+module loads up the other modules and then uses the functions defined in
+them to do something. Having code split up into several modules has
+quite a lot of advantages. If a module is generic enough, the functions
+it exports can be used in a multitude of different programs. If your own
+code is separated into self-contained modules which don’t rely on each
+other too much (we also say they are loosely coupled), you can reuse
+them later on. It makes the whole deal of writing code more manageable
+by having it split into several parts, each of which has some sort of
+purpose.</p>
+<p>The Haskell standard library is split into modules, each of them
+contains functions and types that are somehow related and serve some
+common purpose. There’s a module for manipulating lists, a module for
+concurrent programming, a module for dealing with complex numbers, etc.
+All the functions, types and typeclasses that we’ve dealt with so far
+were part of the <code>Prelude</code> module, which is imported by
+default. In this chapter, we’re going to examine a few useful modules
+and the functions that they have. But first, we’re going to see how to
+import modules.</p>
+<p>The syntax for importing modules in a Haskell script is
+<code>import &lt;module name&gt;</code>. This must be done before
+defining any functions, so imports are usually done at the top of the
+file. One script can, of course, import several modules. Just put each
+import statement into a separate line. Let’s import the
+<code>Data.List</code> module, which has a bunch of useful functions for
+working with lists and use a function that it exports to create a
+function that tells us how many unique elements a list has.</p>
+<pre class="haskell:hs"><code>import Data.List
 
 numUniques :: (Eq a) =&gt; [a] -&gt; Int
-numUniques = length . nub
-</pre>
-<p>When you do <span class="fixed">import Data.List</span>, all the functions that <span class="fixed">Data.List</span> exports become available in the global namespace, meaning that you can call them from wherever in the script. <span class="fixed">nub</span> is a function defined in <span class="fixed">Data.List</span> that takes a list and weeds out duplicate elements. Composing <span class="fixed">length</span> and <span class="fixed">nub</span> by doing <span class="fixed">length . nub</span> produces a function that's the equivalent of <span class="fixed">\xs -&gt; length (nub xs)</span>.</p>
-<p>You can also put the functions of modules into the global namespace when using GHCI. If you're in GHCI and you want to be able to call the functions exported by <span class="fixed">Data.List</span>, do this:</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; :m + Data.List
-</pre>
-<p>If we want to load up the names from several modules inside GHCI, we don't have to do <span class="fixed">:m +</span> several times, we can just load up several modules at once.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; :m + Data.List Data.Map Data.Set
-</pre>
-<p>However, if you've loaded a script that already imports a module, you don't need to use <span class="fixed">:m +</span> to get access to it.</p>
-<p>If you just need a couple of functions from a module, you can selectively import just those functions. If we wanted to import only the <span class="fixed">nub</span> and <span class="fixed">sort</span> functions from <span class="fixed">Data.List</span>, we'd do this:</p>
-<pre name="code" class="haskell:hs">
-import Data.List (nub, sort)
-</pre>
-<p>You can also choose to import all of the functions of a module except a few select ones. That's often useful when several modules export functions with the same name and you want to get rid of the offending ones. Say we already have our own function that's called <span class="fixed">nub</span> and we want to import all the functions from <span class="fixed">Data.List</span> except the <span class="fixed">nub</span> function:
-<pre name="code" class="haskell:hs">
-import Data.List hiding (nub)
-</pre>
-<p>Another way of dealing with name clashes is to do qualified imports. The <span class="fixed">Data.Map</span> module, which offers a data structure for looking up values by key, exports a bunch of functions with the same name as <span class="fixed">Prelude</span> functions, like <span class="fixed">filter</span> or <span class="fixed">null</span>. So when we import <span class="fixed">Data.Map</span> and then call <span class="fixed">filter</span>, Haskell won't know which function to use. Here's how we solve this:</p>
-<pre name="code" class="haskell:hs">
-import qualified Data.Map
-</pre>
-<p>This makes it so that if we want to reference <span class="fixed">Data.Map</span>'s <span class="fixed">filter</span> function, we have to do <span class="fixed">Data.Map.filter</span>, whereas just <span class="fixed">filter</span> still refers to the normal <span class="fixed">filter</span> we all know and love. But typing out <span class="fixed">Data.Map</span> in front of every function from that module is kind of tedious. That's why we can rename the qualified import to something shorter:</p>
-<pre name="code" class="haskell:hs">
-import qualified Data.Map as M
-</pre>
-<p>Now, to reference <span class="fixed">Data.Map</span>'s <span class="fixed">filter</span> function, we just use <span class="fixed">M.filter</span>.</p>
-<p>Use <a href="https://downloads.haskell.org/~ghc/latest/docs/html/libraries/">this handy reference</a> to see which modules are in the standard library. A great way to pick up new Haskell knowledge is to just click through the standard library reference and explore the modules and their functions. You can also view the Haskell source code for each module. Reading the source code of some modules is a really good way to learn Haskell and get a solid feel for it.</p>
-<p>To search for functions or to find out where they're located, use <a href="https://hoogle.haskell.org/">Hoogle</a>. It's a really awesome Haskell search engine, you can search by name, module name or even type signature.</p>
-<a name="data-list"></a><h2>Data.List</h2>
-<p>The <span class="fixed">Data.List</span> module is all about lists, obviously. It provides some very useful functions for dealing with them. We've already met some of its functions (like <span class="fixed">map</span> and <span class="fixed">filter</span>) because the <span class="fixed">Prelude</span> module exports some functions from <span class="fixed">Data.List</span> for convenience. You don't have to import <span class="fixed">Data.List</span> via a qualified import because it doesn't clash with any <span class="fixed">Prelude</span> names except for those that <span class="fixed">Prelude</span> already steals from <span class="fixed">Data.List</span>. Let's take a look at some of the functions that we haven't met before.</p>
-<p><span class="label function">intersperse</span> takes an element and a list and then puts that element in between each pair of elements in the list. Here's a demonstration:</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; intersperse '.' "MONKEY"
-"M.O.N.K.E.Y"
+numUniques = length . nub</code></pre>
+<p>When you do <code>import Data.List</code>, all the functions that
+<code>Data.List</code> exports become available in the global namespace,
+meaning that you can call them from wherever in the script.
+<code>nub</code> is a function defined in <code>Data.List</code> that
+takes a list and weeds out duplicate elements. Composing
+<code>length</code> and <code>nub</code> by doing
+<code>length . nub</code> produces a function that’s the equivalent of
+<code>\xs -&gt; length (nub xs)</code>.</p>
+<p>You can also put the functions of modules into the global namespace
+when using GHCI. If you’re in GHCI and you want to be able to call the
+functions exported by <code>Data.List</code>, do this:</p>
+<pre class="haskell:ghci"><code>ghci&gt; :m + Data.List</code></pre>
+<p>If we want to load up the names from several modules inside GHCI, we
+don’t have to do <code>:m +</code> several times, we can just load up
+several modules at once.</p>
+<pre class="haskell:ghci"><code>ghci&gt; :m + Data.List Data.Map Data.Set</code></pre>
+<p>However, if you’ve loaded a script that already imports a module, you
+don’t need to use <code>:m +</code> to get access to it.</p>
+<p>If you just need a couple of functions from a module, you can
+selectively import just those functions. If we wanted to import only the
+<code>nub</code> and <code>sort</code> functions from
+<code>Data.List</code>, we’d do this:</p>
+<pre class="haskell:hs"><code>import Data.List (nub, sort)</code></pre>
+<p>You can also choose to import all of the functions of a module except
+a few select ones. That’s often useful when several modules export
+functions with the same name and you want to get rid of the offending
+ones. Say we already have our own function that’s called
+<code>nub</code> and we want to import all the functions from
+<code>Data.List</code> except the <code>nub</code> function:</p>
+<pre class="haskell:hs"><code>import Data.List hiding (nub)</code></pre>
+<p>Another way of dealing with name clashes is to do qualified imports.
+The <code>Data.Map</code> module, which offers a data structure for
+looking up values by key, exports a bunch of functions with the same
+name as <code>Prelude</code> functions, like <code>filter</code> or
+<code>null</code>. So when we import <code>Data.Map</code> and then call
+<code>filter</code>, Haskell won’t know which function to use. Here’s
+how we solve this:</p>
+<pre class="haskell:hs"><code>import qualified Data.Map</code></pre>
+<p>This makes it so that if we want to reference <code>Data.Map</code>’s
+<code>filter</code> function, we have to do
+<code>Data.Map.filter</code>, whereas just <code>filter</code> still
+refers to the normal <code>filter</code> we all know and love. But
+typing out <code>Data.Map</code> in front of every function from that
+module is kind of tedious. That’s why we can rename the qualified import
+to something shorter:</p>
+<pre class="haskell:hs"><code>import qualified Data.Map as M</code></pre>
+<p>Now, to reference <code>Data.Map</code>’s <code>filter</code>
+function, we just use <code>M.filter</code>.</p>
+<p>Use <a
+href="https://downloads.haskell.org/~ghc/latest/docs/html/libraries/">this
+handy reference</a> to see which modules are in the standard library. A
+great way to pick up new Haskell knowledge is to just click through the
+standard library reference and explore the modules and their functions.
+You can also view the Haskell source code for each module. Reading the
+source code of some modules is a really good way to learn Haskell and
+get a solid feel for it.</p>
+<p>To search for functions or to find out where they’re located, use <a
+href="https://hoogle.haskell.org/">Hoogle</a>. It’s a really awesome
+Haskell search engine, you can search by name, module name or even type
+signature.</p>
+<h2 id="data-list">Data.List</h2>
+<p>The <code>Data.List</code> module is all about lists, obviously. It
+provides some very useful functions for dealing with them. We’ve already
+met some of its functions (like <code>map</code> and
+<code>filter</code>) because the <code>Prelude</code> module exports
+some functions from <code>Data.List</code> for convenience. You don’t
+have to import <code>Data.List</code> via a qualified import because it
+doesn’t clash with any <code>Prelude</code> names except for those that
+<code>Prelude</code> already steals from <code>Data.List</code>. Let’s
+take a look at some of the functions that we haven’t met before.</p>
+<p><code class="label function">intersperse</code> takes an element and
+a list and then puts that element in between each pair of elements in
+the list. Here’s a demonstration:</p>
+<pre class="haskell:ghci"><code>ghci&gt; intersperse &#39;.&#39; &quot;MONKEY&quot;
+&quot;M.O.N.K.E.Y&quot;
 ghci&gt; intersperse 0 [1,2,3,4,5,6]
-[1,0,2,0,3,0,4,0,5,0,6]
-</pre>
-<p><span class="label function">intercalate</span> takes a list and a list of lists. It then inserts that list in between all those lists and then flattens the result.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; intercalate " " ["hey","there","folks"]
-"hey there folks"
+[1,0,2,0,3,0,4,0,5,0,6]</code></pre>
+<p><code class="label function">intercalate</code> takes a list and a
+list of lists. It then inserts that list in between all those lists and
+then flattens the result.</p>
+<pre class="haskell:ghci"><code>ghci&gt; intercalate &quot; &quot; [&quot;hey&quot;,&quot;there&quot;,&quot;folks&quot;]
+&quot;hey there folks&quot;
 ghci&gt; intercalate [0,0,0] [[1,2,3],[4,5,6],[7,8,9]]
-[1,2,3,0,0,0,4,5,6,0,0,0,7,8,9]
-</pre>
-<p><span class="label function">transpose</span> transposes a list of lists. If you look at a list of lists as a 2D matrix, the columns become the rows and vice versa.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; transpose [[1,2,3],[4,5,6],[7,8,9]]
+[1,2,3,0,0,0,4,5,6,0,0,0,7,8,9]</code></pre>
+<p><code class="label function">transpose</code> transposes a list of
+lists. If you look at a list of lists as a 2D matrix, the columns become
+the rows and vice versa.</p>
+<pre class="haskell:ghci"><code>ghci&gt; transpose [[1,2,3],[4,5,6],[7,8,9]]
 [[1,4,7],[2,5,8],[3,6,9]]
-ghci&gt; transpose ["hey","there","folks"]
-["htg","ehu","yey","rs","e"]
-</pre>
-<p>Say we have the polynomials <i>3x<sup>2</sup> + 5x + 9</i>, <i>10x<sup>3</sup> + 9</i> and <i>8x<sup>3</sup> + 5x<sup>2</sup> + x - 1</i> and we want to add them together. We can use the lists <span class="fixed">[0,3,5,9]</span>, <span class="fixed">[10,0,0,9]</span> and <span class="fixed">[8,5,1,-1]</span> to represent them in Haskell. Now, to add them, all we have to do is this:</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; map sum $ transpose [[0,3,5,9],[10,0,0,9],[8,5,1,-1]]
-[18,8,6,17]
-</pre>
-<p>When we transpose these three lists, the third powers are then in the first row, the second powers in the second one and so on. Mapping <span class="fixed">sum</span> to that produces our desired result.</p>
-<img src="assets/images/modules/legolists.png" alt="shopping lists" class="left" width="230" height="212">
-<p><span class="label function">foldl'</span> and <span class="label function">foldl1'</span> are stricter versions of their respective lazy incarnations. When using lazy folds on really big lists, you might often get a stack overflow error. The culprit for that is that due to the lazy nature of the folds, the accumulator value isn't actually updated as the folding happens. What actually happens is that the accumulator kind of makes a promise that it will compute its value when asked to actually produce the result (also called a thunk). That happens for every intermediate accumulator and all those thunks overflow your stack. The strict folds aren't lazy buggers and actually compute the intermediate values as they go along instead of filling up your stack with thunks. So if you ever get stack overflow errors when doing lazy folds, try switching to their strict versions.</p>
-<p><span class="label function">concat</span> flattens a list of lists into just a list of elements.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; concat ["foo","bar","car"]
-"foobarcar"
+ghci&gt; transpose [&quot;hey&quot;,&quot;there&quot;,&quot;folks&quot;]
+[&quot;htf&quot;,&quot;eho&quot;,&quot;yel&quot;,&quot;rk&quot;,&quot;es&quot;]</code></pre>
+<p>Say we have the polynomials <em>3x<sup>2</sup> + 5x + 9</em>,
+<em>10x<sup>3</sup> + 9</em> and <em>8x<sup>3</sup> + 5x<sup>2</sup> + x
+- 1</em> and we want to add them together. We can use the lists
+<code>[0,3,5,9]</code>, <code>[10,0,0,9]</code> and
+<code>[8,5,1,-1]</code> to represent them in Haskell. Now, to add them,
+all we have to do is this:</p>
+<pre class="haskell:ghci"><code>ghci&gt; map sum $ transpose [[0,3,5,9],[10,0,0,9],[8,5,1,-1]]
+[18,8,6,17]</code></pre>
+<p>When we transpose these three lists, the third powers are then in the
+first row, the second powers in the second one and so on. Mapping
+<code>sum</code> to that produces our desired result.</p>
+<p><img src="assets/images/modules/legolists.png" class="left"
+width="230" height="212" alt="shopping lists" /></p>
+<p><code class="label function">foldl'</code> and <code
+class="label function">foldl1'</code> are stricter versions of their
+respective lazy incarnations. When using lazy folds on really big lists,
+you might often get a stack overflow error. The culprit for that is that
+due to the lazy nature of the folds, the accumulator value isn’t
+actually updated as the folding happens. What actually happens is that
+the accumulator kind of makes a promise that it will compute its value
+when asked to actually produce the result (also called a thunk). That
+happens for every intermediate accumulator and all those thunks overflow
+your stack. The strict folds aren’t lazy buggers and actually compute
+the intermediate values as they go along instead of filling up your
+stack with thunks. So if you ever get stack overflow errors when doing
+lazy folds, try switching to their strict versions.</p>
+<p><code class="label function">concat</code> flattens a list of lists
+into just a list of elements.</p>
+<pre class="haskell:ghci"><code>ghci&gt; concat [&quot;foo&quot;,&quot;bar&quot;,&quot;car&quot;]
+&quot;foobarcar&quot;
 ghci&gt; concat [[3,4,5],[2,3,4],[2,1,1]]
-[3,4,5,2,3,4,2,1,1]
-</pre>
-<p>It will just remove one level of nesting. So if you want to completely flatten <span class="fixed">[[[2,3],[3,4,5],[2]],[[2,3],[3,4]]]</span>, which is a list of lists of lists, you have to concatenate it twice.</p>
-<p>Doing <span class="label function">concatMap</span> is the same as first mapping a function to a list and then concatenating the list with <span class="fixed">concat</span>.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; concatMap (replicate 4) [1..3]
-[1,1,1,1,2,2,2,2,3,3,3,3]
-</pre>
-<p><span class="label function">and</span> takes a list of boolean values and returns <span class="fixed">True</span> only if all the values in the list are <span class="fixed">True</span>.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; and $ map (&gt;4) [5,6,7,8]
+[3,4,5,2,3,4,2,1,1]</code></pre>
+<p>It will just remove one level of nesting. So if you want to
+completely flatten <code>[[[2,3],[3,4,5],[2]],[[2,3],[3,4]]]</code>,
+which is a list of lists of lists, you have to concatenate it twice.</p>
+<p>Doing <code class="label function">concatMap</code> is the same as
+first mapping a function to a list and then concatenating the list with
+<code>concat</code>.</p>
+<pre class="haskell:ghci"><code>ghci&gt; concatMap (replicate 4) [1..3]
+[1,1,1,1,2,2,2,2,3,3,3,3]</code></pre>
+<p><code class="label function">and</code> takes a list of boolean
+values and returns <code>True</code> only if all the values in the list
+are <code>True</code>.</p>
+<pre class="haskell:ghci"><code>ghci&gt; and $ map (&gt;4) [5,6,7,8]
 True
 ghci&gt; and $ map (==4) [4,4,4,3,4]
-False
-</pre>
-<p><span class="label function">or</span> is like <span class="fixed">and</span>, only it returns <span class="fixed">True</span> if any of the boolean values in a list is <span class="fixed">True</span>.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; or $ map (==4) [2,3,4,5,6,1]
+False</code></pre>
+<p><code class="label function">or</code> is like <code>and</code>, only
+it returns <code>True</code> if any of the boolean values in a list is
+<code>True</code>.</p>
+<pre class="haskell:ghci"><code>ghci&gt; or $ map (==4) [2,3,4,5,6,1]
 True
 ghci&gt; or $ map (&gt;4) [1,2,3]
-False
-</pre>
-<p><span class="label function">any</span> and <span class="label function">all</span> take a predicate and then check if any or all the elements in a list satisfy the predicate, respectively. Usually we use these two functions instead of mapping over a list and then doing <span class="fixed">and</span> or <span class="fixed">or</span>.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; any (==4) [2,3,5,6,1,4]
+False</code></pre>
+<p><code class="label function">any</code> and <code
+class="label function">all</code> take a predicate and then check if any
+or all the elements in a list satisfy the predicate, respectively.
+Usually we use these two functions instead of mapping over a list and
+then doing <code>and</code> or <code>or</code>.</p>
+<pre class="haskell:ghci"><code>ghci&gt; any (==4) [2,3,5,6,1,4]
 True
 ghci&gt; all (&gt;4) [6,9,10]
 True
-ghci&gt; all (`elem` ['A'..'Z']) "HEYGUYSwhatsup"
+ghci&gt; all (`elem` [&#39;A&#39;..&#39;Z&#39;]) &quot;HEYGUYSwhatsup&quot;
 False
-ghci&gt; any (`elem` ['A'..'Z']) "HEYGUYSwhatsup"
-True
-</pre>
-<p><span class="label function">iterate</span> takes a function and a starting value. It applies the function to the starting value, then it applies that function to the result, then it applies the function to that result again, etc. It returns all the results in the form of an infinite list.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; take 10 $ iterate (*2) 1
+ghci&gt; any (`elem` [&#39;A&#39;..&#39;Z&#39;]) &quot;HEYGUYSwhatsup&quot;
+True</code></pre>
+<p><code class="label function">iterate</code> takes a function and a
+starting value. It applies the function to the starting value, then it
+applies that function to the result, then it applies the function to
+that result again, etc. It returns all the results in the form of an
+infinite list.</p>
+<pre class="haskell:ghci"><code>ghci&gt; take 10 $ iterate (*2) 1
 [1,2,4,8,16,32,64,128,256,512]
-ghci&gt; take 3 $ iterate (++ "haha") "haha"
-["haha","hahahaha","hahahahahaha"]
-</pre>
-<p><span class="label function">splitAt</span> takes a number and a list. It then splits the list at that many elements, returning the resulting two lists in a tuple.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; splitAt 3 "heyman"
-("hey","man")
-ghci&gt; splitAt 100 "heyman"
-("heyman","")
-ghci&gt; splitAt (-3) "heyman"
-("","heyman")
-ghci&gt; let (a,b) = splitAt 3 "foobar" in b ++ a
-"barfoo"
-</pre>
-<p><span class="label function">takeWhile</span> is a really useful little function. It takes elements from a list while the predicate holds and then when an element is encountered that doesn't satisfy the predicate, it's cut off. It turns out this is very useful.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; takeWhile (&gt;3) [6,5,4,3,2,1,2,3,4,5,4,3,2,1]
+ghci&gt; take 3 $ iterate (++ &quot;haha&quot;) &quot;haha&quot;
+[&quot;haha&quot;,&quot;hahahaha&quot;,&quot;hahahahahaha&quot;]</code></pre>
+<p><code class="label function">splitAt</code> takes a number and a
+list. It then splits the list at that many elements, returning the
+resulting two lists in a tuple.</p>
+<pre class="haskell:ghci"><code>ghci&gt; splitAt 3 &quot;heyman&quot;
+(&quot;hey&quot;,&quot;man&quot;)
+ghci&gt; splitAt 100 &quot;heyman&quot;
+(&quot;heyman&quot;,&quot;&quot;)
+ghci&gt; splitAt (-3) &quot;heyman&quot;
+(&quot;&quot;,&quot;heyman&quot;)
+ghci&gt; let (a,b) = splitAt 3 &quot;foobar&quot; in b ++ a
+&quot;barfoo&quot;</code></pre>
+<p><code class="label function">takeWhile</code> is a really useful
+little function. It takes elements from a list while the predicate holds
+and then when an element is encountered that doesn’t satisfy the
+predicate, it’s cut off. It turns out this is very useful.</p>
+<pre class="haskell:ghci"><code>ghci&gt; takeWhile (&gt;3) [6,5,4,3,2,1,2,3,4,5,4,3,2,1]
 [6,5,4]
-ghci&gt; takeWhile (/=' ') "This is a sentence"
-"This"
-</pre>
-<p>Say we wanted to know the sum of all third powers that are under 10,000. We can't map <span class="fixed">(^3)</span> to <span class="fixed">[1..]</span>, apply a filter and then try to sum that up because filtering an infinite list never finishes. You may know that all the elements here are ascending but Haskell doesn't. That's why we can do this:</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; sum $ takeWhile (<10000) $ map (^3) [1..]
-53361
-</pre>
-<p>We apply <span class="fixed">(^3)</span> to an infinite list and then once an element that's over 10,000 is encountered, the list is cut off. Now we can sum it up easily.</p>
-<p><span class="label function">dropWhile</span> is similar, only it drops all the elements while the predicate is true. Once predicate equates to <span class="fixed">False</span>, it returns the rest of the list. An extremely useful and lovely function!</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; dropWhile (/=' ') "This is a sentence"
-" is a sentence"
-ghci&gt; dropWhile (<3) [1,2,2,2,3,4,5,4,3,2,1]
-[3,4,5,4,3,2,1]
-</pre>
-<p>We're given a list that represents the value of a stock by date. The list is made of tuples whose first component is the stock value, the second is the year, the third is the month and the fourth is the date. We want to know when the stock value first exceeded one thousand dollars!</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; let stock = [(994.4,2008,9,1),(995.2,2008,9,2),(999.2,2008,9,3),(1001.4,2008,9,4),(998.3,2008,9,5)]
-ghci&gt; head (dropWhile (\(val,y,m,d) -&gt; val < 1000) stock)
-(1001.4,2008,9,4)
-</pre>
-<p><span class="label function">span</span> is kind of like <span class="fixed">takeWhile</span>, only it returns a pair of lists. The first list contains everything the resulting list from <span class="fixed">takeWhile</span> would contain if it were called with the same predicate and the same list. The second list contains the part of the list that would have been dropped.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; let (fw, rest) = span (/=' ') "This is a sentence" in "First word:" ++ fw ++ ", the rest:" ++ rest
-"First word: This, the rest: is a sentence"
-</pre>
-<p>Whereas <span class="fixed">span</span> spans the list while the predicate is true, <span class="label function">break</span> breaks it when the predicate is first true. Doing <span class="fixed">break p</span> is the equivalent of doing <span class="fixed">span (not . p)</span>.  </p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; break (==4) [1,2,3,4,5,6,7]
+ghci&gt; takeWhile (/=&#39; &#39;) &quot;This is a sentence&quot;
+&quot;This&quot;</code></pre>
+<p>Say we wanted to know the sum of all third powers that are under
+10,000. We can’t map <code>(^3)</code> to <code>[1..]</code>, apply a
+filter and then try to sum that up because filtering an infinite list
+never finishes. You may know that all the elements here are ascending
+but Haskell doesn’t. That’s why we can do this:</p>
+<pre class="haskell:ghci"><code>ghci&gt; sum $ takeWhile (&lt;10000) $ map (^3) [1..]
+53361</code></pre>
+<p>We apply <code>(^3)</code> to an infinite list and then once an
+element that’s over 10,000 is encountered, the list is cut off. Now we
+can sum it up easily.</p>
+<p><code class="label function">dropWhile</code> is similar, only it
+drops all the elements while the predicate is true. Once predicate
+equates to <code>False</code>, it returns the rest of the list. An
+extremely useful and lovely function!</p>
+<pre class="haskell:ghci"><code>ghci&gt; dropWhile (/=&#39; &#39;) &quot;This is a sentence&quot;
+&quot; is a sentence&quot;
+ghci&gt; dropWhile (&lt;3) [1,2,2,2,3,4,5,4,3,2,1]
+[3,4,5,4,3,2,1]</code></pre>
+<p>We’re given a list that represents the value of a stock by date. The
+list is made of tuples whose first component is the stock value, the
+second is the year, the third is the month and the fourth is the date.
+We want to know when the stock value first exceeded one thousand
+dollars!</p>
+<pre class="haskell:ghci"><code>ghci&gt; let stock = [(994.4,2008,9,1),(995.2,2008,9,2),(999.2,2008,9,3),(1001.4,2008,9,4),(998.3,2008,9,5)]
+ghci&gt; head (dropWhile (\(val,y,m,d) -&gt; val &lt; 1000) stock)
+(1001.4,2008,9,4)</code></pre>
+<p><code class="label function">span</code> is kind of like
+<code>takeWhile</code>, only it returns a pair of lists. The first list
+contains everything the resulting list from <code>takeWhile</code> would
+contain if it were called with the same predicate and the same list. The
+second list contains the part of the list that would have been
+dropped.</p>
+<pre class="haskell:ghci"><code>ghci&gt; let (fw, rest) = span (/=&#39; &#39;) &quot;This is a sentence&quot; in &quot;First word:&quot; ++ fw ++ &quot;, the rest:&quot; ++ rest
+&quot;First word: This, the rest: is a sentence&quot;</code></pre>
+<p>Whereas <code>span</code> spans the list while the predicate is true,
+<code class="label function">break</code> breaks it when the predicate
+is first true. Doing <code>break p</code> is the equivalent of doing
+<code>span (not . p)</code>.</p>
+<pre class="haskell:ghci"><code>ghci&gt; break (==4) [1,2,3,4,5,6,7]
 ([1,2,3],[4,5,6,7])
 ghci&gt; span (/=4) [1,2,3,4,5,6,7]
-([1,2,3],[4,5,6,7])
-</pre>
-<p>When using <span class="fixed">break</span>, the second list in the result will start with the first element that satisfies the predicate.</p>
-<p><span class="label function">sort</span> simply sorts a list. The type of the elements in the list has to be part of the <span class="fixed">Ord</span> typeclass, because if the elements of a list can't be put in some kind of order, then the list can't be sorted.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; sort [8,5,3,2,1,6,4,2]
+([1,2,3],[4,5,6,7])</code></pre>
+<p>When using <code>break</code>, the second list in the result will
+start with the first element that satisfies the predicate.</p>
+<p><code class="label function">sort</code> simply sorts a list. The
+type of the elements in the list has to be part of the <code>Ord</code>
+typeclass, because if the elements of a list can’t be put in some kind
+of order, then the list can’t be sorted.</p>
+<pre class="haskell:ghci"><code>ghci&gt; sort [8,5,3,2,1,6,4,2]
 [1,2,2,3,4,5,6,8]
-ghci&gt; sort "This will be sorted soon"
-"    Tbdeehiillnooorssstw"
-</pre>
-<p><span class="label function">group</span> takes a list and groups adjacent elements into sublists if they are equal.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; group [1,1,1,1,2,2,2,2,3,3,2,2,2,5,6,7]
-[[1,1,1,1],[2,2,2,2],[3,3],[2,2,2],[5],[6],[7]]
-</pre>
-<p>If we sort a list before grouping it, we can find out how many times each element appears in the list.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; map (\l@(x:xs) -&gt; (x,length l)) . group . sort $ [1,1,1,1,2,2,2,2,3,3,2,2,2,5,6,7]
-[(1,4),(2,7),(3,2),(5,1),(6,1),(7,1)]
-</pre>
-<p><span class="label function">inits</span> and <span class="label function">tails</span> are like <span class="fixed">init</span> and <span class="fixed">tail</span>, only they recursively apply that to a list until there's nothing left. Observe.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; inits "w00t"
-["","w","w0","w00","w00t"]
-ghci&gt; tails "w00t"
-["w00t","00t","0t","t",""]
-ghci&gt; let w = "w00t" in zip (inits w) (tails w)
-[("","w00t"),("w","00t"),("w0","0t"),("w00","t"),("w00t","")]
-</pre>
-<p>Let's use a fold to implement searching a list for a sublist.</p>
-<pre name="code" class="haskell:hs">
-search :: (Eq a) =&gt; [a] -&gt; [a] -&gt; Bool
+ghci&gt; sort &quot;This will be sorted soon&quot;
+&quot;    Tbdeehiillnooorssstw&quot;</code></pre>
+<p><code class="label function">group</code> takes a list and groups
+adjacent elements into sublists if they are equal.</p>
+<pre class="haskell:ghci"><code>ghci&gt; group [1,1,1,1,2,2,2,2,3,3,2,2,2,5,6,7]
+[[1,1,1,1],[2,2,2,2],[3,3],[2,2,2],[5],[6],[7]]</code></pre>
+<p>If we sort a list before grouping it, we can find out how many times
+each element appears in the list.</p>
+<pre class="haskell:ghci"><code>ghci&gt; map (\l@(x:xs) -&gt; (x,length l)) . group . sort $ [1,1,1,1,2,2,2,2,3,3,2,2,2,5,6,7]
+[(1,4),(2,7),(3,2),(5,1),(6,1),(7,1)]</code></pre>
+<p><code class="label function">inits</code> and <code
+class="label function">tails</code> are like <code>init</code> and
+<code>tail</code>, only they recursively apply that to a list until
+there’s nothing left. Observe.</p>
+<pre class="haskell:ghci"><code>ghci&gt; inits &quot;w00t&quot;
+[&quot;&quot;,&quot;w&quot;,&quot;w0&quot;,&quot;w00&quot;,&quot;w00t&quot;]
+ghci&gt; tails &quot;w00t&quot;
+[&quot;w00t&quot;,&quot;00t&quot;,&quot;0t&quot;,&quot;t&quot;,&quot;&quot;]
+ghci&gt; let w = &quot;w00t&quot; in zip (inits w) (tails w)
+[(&quot;&quot;,&quot;w00t&quot;),(&quot;w&quot;,&quot;00t&quot;),(&quot;w0&quot;,&quot;0t&quot;),(&quot;w00&quot;,&quot;t&quot;),(&quot;w00t&quot;,&quot;&quot;)]</code></pre>
+<p>Let’s use a fold to implement searching a list for a sublist.</p>
+<pre class="haskell:hs"><code>search :: (Eq a) =&gt; [a] -&gt; [a] -&gt; Bool
 search needle haystack =
     let nlen = length needle
-    in  foldl (\acc x -&gt; if take nlen x == needle then True else acc) False (tails haystack)
-</pre>
-<p>First we call <span class="fixed">tails</span> with the list in which we're searching. Then we go over each tail and see if it starts with what we're looking for.</p>
-<p>With that, we actually just made a function that behaves like <span class="label function">isInfixOf</span>. <span class="fixed">isInfixOf</span> searches for a sublist within a list and returns <span class="fixed">True</span> if the sublist we're looking for is somewhere inside the target list.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; "cat" `isInfixOf` "im a cat burglar"
+    in  foldl (\acc x -&gt; if take nlen x == needle then True else acc) False (tails haystack)</code></pre>
+<p>First we call <code>tails</code> with the list in which we’re
+searching. Then we go over each tail and see if it starts with what
+we’re looking for.</p>
+<p>With that, we actually just made a function that behaves like <code
+class="label function">isInfixOf</code>. <code>isInfixOf</code> searches
+for a sublist within a list and returns <code>True</code> if the sublist
+we’re looking for is somewhere inside the target list.</p>
+<pre class="haskell:ghci"><code>ghci&gt; &quot;cat&quot; `isInfixOf` &quot;im a cat burglar&quot;
 True
-ghci&gt; "Cat" `isInfixOf` "im a cat burglar"
+ghci&gt; &quot;Cat&quot; `isInfixOf` &quot;im a cat burglar&quot;
 False
-ghci&gt; "cats" `isInfixOf` "im a cat burglar"
-False
-</pre>
-<p><span class="label function">isPrefixOf</span> and <span class="label function">isSuffixOf</span> search for a sublist at the beginning and at the end of a list, respectively.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; "hey" `isPrefixOf` "hey there!"
+ghci&gt; &quot;cats&quot; `isInfixOf` &quot;im a cat burglar&quot;
+False</code></pre>
+<p><code class="label function">isPrefixOf</code> and <code
+class="label function">isSuffixOf</code> search for a sublist at the
+beginning and at the end of a list, respectively.</p>
+<pre class="haskell:ghci"><code>ghci&gt; &quot;hey&quot; `isPrefixOf` &quot;hey there!&quot;
 True
-ghci&gt; "hey" `isPrefixOf` "oh hey there!"
+ghci&gt; &quot;hey&quot; `isPrefixOf` &quot;oh hey there!&quot;
 False
-ghci&gt; "there!" `isSuffixOf` "oh hey there!"
+ghci&gt; &quot;there!&quot; `isSuffixOf` &quot;oh hey there!&quot;
 True
-ghci&gt; "there!" `isSuffixOf` "oh hey there"
-False
-</pre>
-<p><span class="label function">elem</span> and <span class="label function">notElem</span> check if an element is or isn't inside a list. </p>
-<p><span class="label function">partition</span> takes a list and a predicate and returns a pair of lists. The first list in the result contains all the elements that satisfy the predicate, the second contains all the ones that don't.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; partition (`elem` ['A'..'Z']) "BOBsidneyMORGANeddy"
-("BOBMORGAN","sidneyeddy")
+ghci&gt; &quot;there!&quot; `isSuffixOf` &quot;oh hey there&quot;
+False</code></pre>
+<p><code class="label function">elem</code> and <code
+class="label function">notElem</code> check if an element is or isn’t
+inside a list.</p>
+<p><code class="label function">partition</code> takes a list and a
+predicate and returns a pair of lists. The first list in the result
+contains all the elements that satisfy the predicate, the second
+contains all the ones that don’t.</p>
+<pre class="haskell:ghci"><code>ghci&gt; partition (`elem` [&#39;A&#39;..&#39;Z&#39;]) &quot;BOBsidneyMORGANeddy&quot;
+(&quot;BOBMORGAN&quot;,&quot;sidneyeddy&quot;)
 ghci&gt; partition (&gt;3) [1,3,5,6,3,2,1,0,3,7]
-([5,6,7],[1,3,3,2,1,0,3])
-</pre>
-<p>It's important to understand how this is different from <span class="fixed">span</span> and <span class="fixed">break</span>:</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; span (`elem` ['A'..'Z']) "BOBsidneyMORGANeddy"
-("BOB","sidneyMORGANeddy")
-</pre>
-<p>While <span class="fixed">span</span> and <span class="fixed">break</span> are done once they encounter the first element that doesn't and does satisfy the predicate, <span class="fixed">partition</span> goes through the whole list and splits it up according to the predicate.</p>
-<p><span class="label function">find</span> takes a list and a predicate and returns the first element that satisfies the predicate. But it returns that element wrapped in a <span class="fixed">Maybe</span> value. We'll be covering algebraic data types more in depth in the next chapter but for now, this is what you need to know: a <span class="fixed">Maybe</span> value can either be <span class="fixed">Just something</span> or <span class="fixed">Nothing</span>. Much like a list can be either an empty list or a list with some elements, a <span class="fixed">Maybe</span> value can be either no elements or a single element. And like the type of a list of, say, integers is <span class="fixed">[Int]</span>, the type of maybe having an integer is <span class="fixed">Maybe Int</span>. Anyway, let's take our <span class="fixed">find</span> function for a spin.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; find (&gt;4) [1,2,3,4,5,6]
+([5,6,7],[1,3,3,2,1,0,3])</code></pre>
+<p>It’s important to understand how this is different from
+<code>span</code> and <code>break</code>:</p>
+<pre class="haskell:ghci"><code>ghci&gt; span (`elem` [&#39;A&#39;..&#39;Z&#39;]) &quot;BOBsidneyMORGANeddy&quot;
+(&quot;BOB&quot;,&quot;sidneyMORGANeddy&quot;)</code></pre>
+<p>While <code>span</code> and <code>break</code> are done once they
+encounter the first element that doesn’t and does satisfy the predicate,
+<code>partition</code> goes through the whole list and splits it up
+according to the predicate.</p>
+<p><code class="label function">find</code> takes a list and a predicate
+and returns the first element that satisfies the predicate. But it
+returns that element wrapped in a <code>Maybe</code> value. We’ll be
+covering algebraic data types more in depth in the next chapter but for
+now, this is what you need to know: a <code>Maybe</code> value can
+either be <code>Just something</code> or <code>Nothing</code>. Much like
+a list can be either an empty list or a list with some elements, a
+<code>Maybe</code> value can be either no elements or a single element.
+And like the type of a list of, say, integers is <code>[Int]</code>, the
+type of maybe having an integer is <code>Maybe Int</code>. Anyway, let’s
+take our <code>find</code> function for a spin.</p>
+<pre class="haskell:ghci"><code>ghci&gt; find (&gt;4) [1,2,3,4,5,6]
 Just 5
 ghci&gt; find (&gt;9) [1,2,3,4,5,6]
 Nothing
 ghci&gt; :t find
-find :: (a -&gt; Bool) -&gt; [a] -&gt; Maybe a
-</pre>
-<p>Notice the type of <span class="fixed">find</span>. Its result is <span class="fixed">Maybe a</span>. That's kind of like having the type of <span class="fixed">[a]</span>, only a value of the type <span class="fixed">Maybe</span> can contain either no elements or one element, whereas a list can contain no elements, one element or several elements.</p>
-<p>Remember when we were searching for the first time our stock went over $1000. We did <span class="fixed">head (dropWhile (\(val,y,m,d) -&gt; val &lt; 1000) stock)</span>. Remember that <span class="fixed">head</span> is not really safe. What would happen if our stock never went over $1000? Our application of <span class="fixed">dropWhile</span> would return an empty list and getting the head of an empty list would result in an error. However, if we rewrote that as <span class="fixed">find (\(val,y,m,d) -&gt; val &gt; 1000) stock</span>, we'd be much safer. If our stock never went over $1000 (so if no element satisfied the predicate), we'd get back a <span class="fixed">Nothing</span>. But if there was a valid answer in that list, we'd get, say, <span class="fixed">Just (1001.4,2008,9,4)</span>.
-<p><span class="label function">elemIndex</span> is kind of like <span class="fixed">elem</span>, only it doesn't return a boolean value. It maybe returns the index of the element we're looking for. If that element isn't in our list, it returns a <span class="fixed">Nothing</span>.  </p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; :t elemIndex
+find :: (a -&gt; Bool) -&gt; [a] -&gt; Maybe a</code></pre>
+<p>Notice the type of <code>find</code>. Its result is
+<code>Maybe a</code>. That’s kind of like having the type of
+<code>[a]</code>, only a value of the type <code>Maybe</code> can
+contain either no elements or one element, whereas a list can contain no
+elements, one element or several elements.</p>
+<p>Remember when we were searching for the first time our stock went
+over $1000. We did
+<code>head (dropWhile (\(val,y,m,d) -&gt; val &lt; 1000) stock)</code>.
+Remember that <code>head</code> is not really safe. What would happen if
+our stock never went over $1000? Our application of
+<code>dropWhile</code> would return an empty list and getting the head
+of an empty list would result in an error. However, if we rewrote that
+as <code>find (\(val,y,m,d) -&gt; val &gt; 1000) stock</code>, we’d be
+much safer. If our stock never went over $1000 (so if no element
+satisfied the predicate), we’d get back a <code>Nothing</code>. But if
+there was a valid answer in that list, we’d get, say,
+<code>Just (1001.4,2008,9,4)</code>.</p>
+<p><code class="label function">elemIndex</code> is kind of like
+<code>elem</code>, only it doesn’t return a boolean value. It maybe
+returns the index of the element we’re looking for. If that element
+isn’t in our list, it returns a <code>Nothing</code>.</p>
+<pre class="haskell:ghci"><code>ghci&gt; :t elemIndex
 elemIndex :: (Eq a) =&gt; a -&gt; [a] -&gt; Maybe Int
 ghci&gt; 4 `elemIndex` [1,2,3,4,5,6]
 Just 3
 ghci&gt; 10 `elemIndex` [1,2,3,4,5,6]
-Nothing
-</pre>
-<p><span class="label function">elemIndices</span> is like <span class="fixed">elemIndex</span>, only it returns a list of indices, in case the element we're looking for crops up in our list several times. Because we're using a list to represent the indices, we don't need a <span class="fixed">Maybe</span> type, because failure can be represented as the empty list, which is very much synonymous to <span class="fixed">Nothing</span>.  </p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; ' ' `elemIndices` "Where are the spaces?"
-[5,9,13]
-</pre>
-<p><span class="label function">findIndex</span> is like find, but it maybe returns the index of the first element that satisfies the predicate. <span class="label function">findIndices</span> returns the indices of all elements that satisfy the predicate in the form of a list.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; findIndex (==4) [5,3,2,1,6,4]
+Nothing</code></pre>
+<p><code class="label function">elemIndices</code> is like
+<code>elemIndex</code>, only it returns a list of indices, in case the
+element we’re looking for crops up in our list several times. Because
+we’re using a list to represent the indices, we don’t need a
+<code>Maybe</code> type, because failure can be represented as the empty
+list, which is very much synonymous to <code>Nothing</code>.</p>
+<pre class="haskell:ghci"><code>ghci&gt; &#39; &#39; `elemIndices` &quot;Where are the spaces?&quot;
+[5,9,13]</code></pre>
+<p><code class="label function">findIndex</code> is like find, but it
+maybe returns the index of the first element that satisfies the
+predicate. <code class="label function">findIndices</code> returns the
+indices of all elements that satisfy the predicate in the form of a
+list.</p>
+<pre class="haskell:ghci"><code>ghci&gt; findIndex (==4) [5,3,2,1,6,4]
 Just 5
 ghci&gt; findIndex (==7) [5,3,2,1,6,4]
 Nothing
-ghci&gt; findIndices (`elem` ['A'..'Z']) "Where Are The Caps?"
-[0,6,10,14]
-</pre>
-<p>We already covered <span class="fixed">zip</span> and <span class="fixed">zipWith</span>. We noted that they zip together two lists, either in a tuple or with a binary function (meaning such a function that takes two parameters). But what if we want to zip together three lists? Or zip three lists with a function that takes three parameters? Well, for that, we have <span class="label function">zip3</span>, <span class="label function">zip4</span>, etc. and <span class="label function">zipWith3</span>, <span class="label function">zipWith4</span>, etc. These variants go up to 7. While this may look like a hack, it works out pretty fine, because there aren't many times when you want to zip 8 lists together. There's also a very clever way for zipping infinite numbers of lists, but we're not advanced enough to cover that just yet.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; zipWith3 (\x y z -&gt; x + y + z) [1,2,3] [4,5,2,2] [2,2,3]
+ghci&gt; findIndices (`elem` [&#39;A&#39;..&#39;Z&#39;]) &quot;Where Are The Caps?&quot;
+[0,6,10,14]</code></pre>
+<p>We already covered <code>zip</code> and <code>zipWith</code>. We
+noted that they zip together two lists, either in a tuple or with a
+binary function (meaning such a function that takes two parameters). But
+what if we want to zip together three lists? Or zip three lists with a
+function that takes three parameters? Well, for that, we have <code
+class="label function">zip3</code>, <code
+class="label function">zip4</code>, etc. and <code
+class="label function">zipWith3</code>, <code
+class="label function">zipWith4</code>, etc. These variants go up to 7.
+While this may look like a hack, it works out pretty fine, because there
+aren’t many times when you want to zip 8 lists together. There’s also a
+very clever way for zipping infinite numbers of lists, but we’re not
+advanced enough to cover that just yet.</p>
+<pre class="haskell:ghci"><code>ghci&gt; zipWith3 (\x y z -&gt; x + y + z) [1,2,3] [4,5,2,2] [2,2,3]
 [7,9,8]
 ghci&gt; zip4 [2,3,3] [2,2,2] [5,5,3] [2,2,2]
-[(2,2,5,2),(3,2,5,2),(3,2,3,2)]
-</pre>
-<p>Just like with normal zipping, lists that are longer than the shortest list that's being zipped are cut down to size.</p>
-<p><span class="label function">lines</span> is a useful function when dealing with files or input from somewhere. It takes a string and returns every line of that string as separate element of a list.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; lines "first line\nsecond line\nthird line"
-["first line","second line","third line"]
-</pre>
-<p><span class="fixed">'\n'</span> is the character for a unix newline. Backslashes have special meaning in Haskell strings and characters.</p>
-<p><span class="label function">unlines</span> is the inverse function of <span class="fixed">lines</span>. It takes a list of strings and joins them together using a <span class="fixed">'\n'</span>.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; unlines ["first line", "second line", "third line"]
-"first line\nsecond line\nthird line\n"
-</pre>
-<p><span class="label function">words</span> and <span class="label function">unwords</span> are for splitting a line of text into words or joining a list of words into a text. Very useful.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; words "hey these are the words in this sentence"
-["hey","these","are","the","words","in","this","sentence"]
-ghci&gt; words "hey these           are    the words in this\nsentence"
-["hey","these","are","the","words","in","this","sentence"]
-ghci&gt; unwords ["hey","there","mate"]
-"hey there mate"
-</pre>
-<p>We've already mentioned <span class="label function">nub</span>. It takes a list and weeds out the duplicate elements, returning a list whose every element is a unique snowflake! The function does have a kind of strange name. It turns out that "nub" means a small lump or essential part of something. In my opinion, they should use real words for function names instead of old-people words.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; nub [1,2,3,4,3,2,1,2,3,4,3,2,1]
+[(2,2,5,2),(3,2,5,2),(3,2,3,2)]</code></pre>
+<p>Just like with normal zipping, lists that are longer than the
+shortest list that’s being zipped are cut down to size.</p>
+<p><code class="label function">lines</code> is a useful function when
+dealing with files or input from somewhere. It takes a string and
+returns every line of that string as separate element of a list.</p>
+<pre class="haskell:ghci"><code>ghci&gt; lines &quot;first line\nsecond line\nthird line&quot;
+[&quot;first line&quot;,&quot;second line&quot;,&quot;third line&quot;]</code></pre>
+<p><code>'\n'</code> is the character for a unix newline. Backslashes
+have special meaning in Haskell strings and characters.</p>
+<p><code class="label function">unlines</code> is the inverse function
+of <code>lines</code>. It takes a list of strings and joins them
+together using a <code>'\n'</code>.</p>
+<pre class="haskell:ghci"><code>ghci&gt; unlines [&quot;first line&quot;, &quot;second line&quot;, &quot;third line&quot;]
+&quot;first line\nsecond line\nthird line\n&quot;</code></pre>
+<p><code class="label function">words</code> and <code
+class="label function">unwords</code> are for splitting a line of text
+into words or joining a list of words into a text. Very useful.</p>
+<pre class="haskell:ghci"><code>ghci&gt; words &quot;hey these are the words in this sentence&quot;
+[&quot;hey&quot;,&quot;these&quot;,&quot;are&quot;,&quot;the&quot;,&quot;words&quot;,&quot;in&quot;,&quot;this&quot;,&quot;sentence&quot;]
+ghci&gt; words &quot;hey these           are    the words in this\nsentence&quot;
+[&quot;hey&quot;,&quot;these&quot;,&quot;are&quot;,&quot;the&quot;,&quot;words&quot;,&quot;in&quot;,&quot;this&quot;,&quot;sentence&quot;]
+ghci&gt; unwords [&quot;hey&quot;,&quot;there&quot;,&quot;mate&quot;]
+&quot;hey there mate&quot;</code></pre>
+<p>We’ve already mentioned <code class="label function">nub</code>. It
+takes a list and weeds out the duplicate elements, returning a list
+whose every element is a unique snowflake! The function does have a kind
+of strange name. It turns out that “nub” means a small lump or essential
+part of something. In my opinion, they should use real words for
+function names instead of old-people words.</p>
+<pre class="haskell:ghci"><code>ghci&gt; nub [1,2,3,4,3,2,1,2,3,4,3,2,1]
 [1,2,3,4]
-ghci&gt; nub "Lots of words and stuff"
-"Lots fwrdanu"
-</pre>
-<p><span class="label function">delete</span> takes an element and a list and deletes the first occurrence of that element in the list.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; delete 'h' "hey there ghang!"
-"ey there ghang!"
-ghci&gt; delete 'h' . delete 'h' $ "hey there ghang!"
-"ey tere ghang!"
-ghci&gt; delete 'h' . delete 'h' . delete 'h' $ "hey there ghang!"
-"ey tere gang!"
-</pre>
-<p><span class="label function">\\</span> is the list difference function. It acts like a set difference, basically. For every element in the right-hand list, it removes a matching element in the left one.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; [1..10] \\ [2,5,9]
+ghci&gt; nub &quot;Lots of words and stuff&quot;
+&quot;Lots fwrdanu&quot;</code></pre>
+<p><code class="label function">delete</code> takes an element and a
+list and deletes the first occurrence of that element in the list.</p>
+<pre class="haskell:ghci"><code>ghci&gt; delete &#39;h&#39; &quot;hey there ghang!&quot;
+&quot;ey there ghang!&quot;
+ghci&gt; delete &#39;h&#39; . delete &#39;h&#39; $ &quot;hey there ghang!&quot;
+&quot;ey tere ghang!&quot;
+ghci&gt; delete &#39;h&#39; . delete &#39;h&#39; . delete &#39;h&#39; $ &quot;hey there ghang!&quot;
+&quot;ey tere gang!&quot;</code></pre>
+<p><code class="label function">\\</code> is the list difference
+function. It acts like a set difference, basically. For every element in
+the right-hand list, it removes a matching element in the left one.</p>
+<pre class="haskell:ghci"><code>ghci&gt; [1..10] \\ [2,5,9]
 [1,3,4,6,7,8,10]
-ghci&gt; "Im a big baby" \\ "big"
-"Im a  baby"
-</pre>
-<p>Doing <span class="fixed">[1..10] \\ [2,5,9]</span> is like doing <span class="fixed">delete 2 . delete 5 . delete 9 $ [1..10]</span>.</p>
-<p><span class="label function">union</span> also acts like a function on sets. It returns the union of two lists. It pretty much goes over every element in the second list and appends it to the first one if it isn't already in yet. Watch out though, duplicates are removed from the second list!</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; "hey man" `union` "man what's up"
-"hey manwt'sup"
+ghci&gt; &quot;Im a big baby&quot; \\ &quot;big&quot;
+&quot;Im a  baby&quot;</code></pre>
+<p>Doing <code>[1..10] \\ [2,5,9]</code> is like doing
+<code>delete 2 . delete 5 . delete 9 $ [1..10]</code>.</p>
+<p><code class="label function">union</code> also acts like a function
+on sets. It returns the union of two lists. It pretty much goes over
+every element in the second list and appends it to the first one if it
+isn’t already in yet. Watch out though, duplicates are removed from the
+second list!</p>
+<pre class="haskell:ghci"><code>ghci&gt; &quot;hey man&quot; `union` &quot;man what&#39;s up&quot;
+&quot;hey manwt&#39;sup&quot;
 ghci&gt; [1..7] `union` [5..10]
-[1,2,3,4,5,6,7,8,9,10]
-</pre>
-<p><span class="label function">intersect</span> works like set intersection. It returns only the elements that are found in both lists.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; [1..7] `intersect` [5..10]
-[5,6,7]
-</pre>
-<p><span class="label function">insert</span> takes an element and a list of elements that can be sorted and inserts it into the last position where it's still less than or equal to the next element. In other words, <span class="fixed">insert</span> will start at the beginning of the list and then keep going until it finds an element that's equal to or greater than the element that we're inserting and it will insert it just before the element.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; insert 4 [3,5,1,2,8,2]
+[1,2,3,4,5,6,7,8,9,10]</code></pre>
+<p><code class="label function">intersect</code> works like set
+intersection. It returns only the elements that are found in both
+lists.</p>
+<pre class="haskell:ghci"><code>ghci&gt; [1..7] `intersect` [5..10]
+[5,6,7]</code></pre>
+<p><code class="label function">insert</code> takes an element and a
+list of elements that can be sorted and inserts it into the last
+position where it’s still less than or equal to the next element. In
+other words, <code>insert</code> will start at the beginning of the list
+and then keep going until it finds an element that’s equal to or greater
+than the element that we’re inserting and it will insert it just before
+the element.</p>
+<pre class="haskell:ghci"><code>ghci&gt; insert 4 [3,5,1,2,8,2]
 [3,4,5,1,2,8,2]
 ghci&gt; insert 4 [1,3,4,4,1]
-[1,3,4,4,4,1]
-</pre>
-<p>The <span class="fixed">4</span> is inserted right after the <span class="fixed">3</span> and before the <span class="fixed">5</span> in the first example and in between the <span class="fixed">3</span> and <span class="fixed">4</span> in the second example.</p>
-If we use <span class="fixed">insert</span> to insert into a sorted list, the resulting list will be kept sorted.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; insert 4 [1,2,3,5,6,7]
+[1,3,4,4,4,1]</code></pre>
+<p>The <code>4</code> is inserted right after the <code>3</code> and
+before the <code>5</code> in the first example and in between the
+<code>3</code> and <code>4</code> in the second example.</p>
+<p>If we use <code>insert</code> to insert into a sorted list, the
+resulting list will be kept sorted.</p>
+<pre class="haskell:ghci"><code>ghci&gt; insert 4 [1,2,3,5,6,7]
 [1,2,3,4,5,6,7]
-ghci&gt; insert 'g' $ ['a'..'f'] ++ ['h'..'z']
-"abcdefghijklmnopqrstuvwxyz"
+ghci&gt; insert &#39;g&#39; $ [&#39;a&#39;..&#39;f&#39;] ++ [&#39;h&#39;..&#39;z&#39;]
+&quot;abcdefghijklmnopqrstuvwxyz&quot;
 ghci&gt; insert 3 [1,2,4,3,2,1]
-[1,2,3,4,3,2,1]
-</pre>
-<p>What <span class="fixed">length</span>, <span class="fixed">take</span>, <span class="fixed">drop</span>, <span class="fixed">splitAt</span>, <span class="fixed">!!</span> and <span class="fixed">replicate</span> have in common is that they take an <span class="fixed">Int</span> as one of their parameters (or return an <span class="fixed">Int</span>), even though they could be more generic and usable if they just took any type that's part of the <span class="fixed">Integral</span> or <span class="fixed">Num</span> typeclasses (depending on the functions). They do that for historical reasons. However, fixing that would probably break a lot of existing code. That's why <span class="fixed">Data.List</span> has their more generic equivalents, named <span class="label function">genericLength</span>, <span class="label function">genericTake</span>, <span class="label function">genericDrop</span>, <span class="label function">genericSplitAt</span>, <span class="label function">genericIndex</span> and <span class="label function">genericReplicate</span>. For instance, <span class="fixed">length</span> has a type signature of <span class="fixed">length :: [a] -&gt; Int</span>. If we try to get the average of a list of numbers by doing <span class="fixed">let xs = [1..6] in sum xs / length xs</span>, we get a type error, because you can't use <span class="fixed">/</span> with an <span class="fixed">Int</span>. <span class="fixed">genericLength</span>, on the other hand, has a type signature of <span class="fixed">genericLength :: (Num a) =&gt; [b] -&gt; a</span>. Because a <span class="fixed">Num</span> can act like a floating point number, getting the average by doing <span class="fixed">let xs = [1..6] in sum xs / genericLength xs</span> works out just fine.</p>
-<p>The <span class="fixed">nub</span>, <span class="fixed">delete</span>, <span class="fixed">union</span>, <span class="fixed">intersect</span> and <span class="fixed">group</span> functions all have their more general counterparts called <span class="label function">nubBy</span>, <span class="label function">deleteBy</span>, <span class="label function">unionBy</span>, <span class="label function">intersectBy</span> and <span class="label function">groupBy</span>. The difference between them is that the first set of functions use <span class="fixed">==</span> to test for equality, whereas the <i>By</i> ones also take an equality function and then compare them by using that equality function. <span class="fixed">group</span> is the same as <span class="fixed">groupBy (==)</span>. </p>
-<p>For instance, say we have a list that describes the value of a function for every second. We want to segment it into sublists based on when the value was below zero and when it went above. If we just did a normal <span class="fixed">group</span>, it would just group the equal adjacent values together. But what we want is to group them by whether they are negative or not. That's where <span class="fixed">groupBy</span> comes in! The equality function supplied to the <i>By</i> functions should take two elements of the same type and return <span class="fixed">True</span> if it considers them equal by its standards.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; let values = [-4.3, -2.4, -1.2, 0.4, 2.3, 5.9, 10.5, 29.1, 5.3, -2.4, -14.5, 2.9, 2.3]
+[1,2,3,4,3,2,1]</code></pre>
+<p>What <code>length</code>, <code>take</code>, <code>drop</code>,
+<code>splitAt</code>, <code>!!</code> and <code>replicate</code> have in
+common is that they take an <code>Int</code> as one of their parameters
+(or return an <code>Int</code>), even though they could be more generic
+and usable if they just took any type that’s part of the
+<code>Integral</code> or <code>Num</code> typeclasses (depending on the
+functions). They do that for historical reasons. However, fixing that
+would probably break a lot of existing code. That’s why
+<code>Data.List</code> has their more generic equivalents, named <code
+class="label function">genericLength</code>, <code
+class="label function">genericTake</code>, <code
+class="label function">genericDrop</code>, <code
+class="label function">genericSplitAt</code>, <code
+class="label function">genericIndex</code> and <code
+class="label function">genericReplicate</code>. For instance,
+<code>length</code> has a type signature of
+<code>length :: [a] -&gt; Int</code>. If we try to get the average of a
+list of numbers by doing
+<code>let xs = [1..6] in sum xs / length xs</code>, we get a type error,
+because you can’t use <code>/</code> with an <code>Int</code>.
+<code>genericLength</code>, on the other hand, has a type signature of
+<code>genericLength :: (Num a) =&gt; [b] -&gt; a</code>. Because a
+<code>Num</code> can act like a floating point number, getting the
+average by doing
+<code>let xs = [1..6] in sum xs / genericLength xs</code> works out just
+fine.</p>
+<p>The <code>nub</code>, <code>delete</code>, <code>union</code>,
+<code>intersect</code> and <code>group</code> functions all have their
+more general counterparts called <code
+class="label function">nubBy</code>, <code
+class="label function">deleteBy</code>, <code
+class="label function">unionBy</code>, <code
+class="label function">intersectBy</code> and <code
+class="label function">groupBy</code>. The difference between them is
+that the first set of functions use <code>==</code> to test for
+equality, whereas the <em>By</em> ones also take an equality function
+and then compare them by using that equality function.
+<code>group</code> is the same as <code>groupBy (==)</code>.</p>
+<p>For instance, say we have a list that describes the value of a
+function for every second. We want to segment it into sublists based on
+when the value was below zero and when it went above. If we just did a
+normal <code>group</code>, it would just group the equal adjacent values
+together. But what we want is to group them by whether they are negative
+or not. That’s where <code>groupBy</code> comes in! The equality
+function supplied to the <em>By</em> functions should take two elements
+of the same type and return <code>True</code> if it considers them equal
+by its standards.</p>
+<pre class="haskell:ghci"><code>ghci&gt; let values = [-4.3, -2.4, -1.2, 0.4, 2.3, 5.9, 10.5, 29.1, 5.3, -2.4, -14.5, 2.9, 2.3]
 ghci&gt; groupBy (\x y -&gt; (x &gt; 0) == (y &gt; 0)) values
-[[-4.3,-2.4,-1.2],[0.4,2.3,5.9,10.5,29.1,5.3],[-2.4,-14.5],[2.9,2.3]]
-</pre>
-<p>From this, we clearly see which sections are positive and which are negative. The equality function supplied takes two elements and then returns <span class="fixed">True</span> only if they're both negative or if they're both positive. This equality function can also be written as <span class="fixed">\x y -&gt; (x &gt; 0) &amp;&amp; (y &gt; 0) || (x &lt;= 0) &amp;&amp; (y &lt;= 0)</span>, although I think the first way is more readable. An even clearer way to write equality functions for the <i>By</i> functions is if you import the <span class="label function">on</span> function from <span class="fixed">Data.Function</span>. <span class="fixed">on</span> is defined like this:
-<pre name="code" class="haskell:ghci">
-on :: (b -&gt; b -&gt; c) -&gt; (a -&gt; b) -&gt; a -&gt; a -&gt; c
-f `on` g = \x y -&gt; f (g x) (g y)
-</pre>
-<p>So doing <span class="fixed">(==) `on` (&gt; 0)</span> returns an equality function that looks like <span class="fixed">\x y -&gt; (x &gt; 0) == (y &gt; 0)</span>. <span class="fixed">on</span> is used a lot with the <i>By</i> functions because with it, we can do:
-<pre name="code" class="haskell:ghci">
-ghci&gt; groupBy ((==) `on` (&gt; 0)) values
-[[-4.3,-2.4,-1.2],[0.4,2.3,5.9,10.5,29.1,5.3],[-2.4,-14.5],[2.9,2.3]]
-</pre>
-<p>Very readable indeed! You can read it out loud: Group this by equality on whether the elements are greater than zero.</p>
-<p>Similarly, the <span class="fixed">sort</span>, <span class="fixed">insert</span>, <span class="fixed">maximum</span> and <span class="fixed">minimum</span> also have their more general equivalents. Functions like <span class="fixed">groupBy</span> take a function that determines when two elements are equal. <span class="label function">sortBy</span>, <span class="label function">insertBy</span>, <span class="label function">maximumBy</span> and <span class="label function">minimumBy</span> take a function that determine if one element is greater, smaller or equal to the other. The type signature of <span class="fixed">sortBy</span> is <span class="fixed">sortBy :: (a -&gt; a -&gt; Ordering) -&gt; [a] -&gt; [a]</span>. If you remember from before, the <span class="fixed">Ordering</span> type can have a value of <span class="fixed">LT</span>, <span class="fixed">EQ</span> or <span class="fixed">GT</span>. <span class="fixed">sort</span> is the equivalent of <span class="fixed">sortBy compare</span>, because compare just takes two elements whose type is in the <span class="fixed">Ord</span> typeclass and returns their ordering relationship.</p>
-<p>Lists can be compared, but when they are, they are compared lexicographically. What if we have a list of lists and we want to sort it not based on the inner lists' contents but on their lengths? Well, as you've probably guessed, we'll use the <span class="fixed">sortBy</span> function.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; let xs = [[5,4,5,4,4],[1,2,3],[3,5,4,3],[],[2],[2,2]]
+[[-4.3,-2.4,-1.2],[0.4,2.3,5.9,10.5,29.1,5.3],[-2.4,-14.5],[2.9,2.3]]</code></pre>
+<p>From this, we clearly see which sections are positive and which are
+negative. The equality function supplied takes two elements and then
+returns <code>True</code> only if they’re both negative or if they’re
+both positive. This equality function can also be written as
+<code>\x y -&gt; (x &gt; 0) &amp;&amp; (y &gt; 0) || (x &lt;= 0) &amp;&amp; (y &lt;= 0)</code>,
+although I think the first way is more readable. An even clearer way to
+write equality functions for the <em>By</em> functions is if you import
+the <code class="label function">on</code> function from
+<code>Data.Function</code>. <code>on</code> is defined like this:</p>
+<pre class="haskell:ghci"><code>on :: (b -&gt; b -&gt; c) -&gt; (a -&gt; b) -&gt; a -&gt; a -&gt; c
+f `on` g = \x y -&gt; f (g x) (g y)</code></pre>
+<p>So doing <code>(==) `on` (&gt; 0)</code> returns an equality function
+that looks like <code>\x y -&gt; (x &gt; 0) == (y &gt; 0)</code>.
+<code>on</code> is used a lot with the <em>By</em> functions because
+with it, we can do:</p>
+<pre class="haskell:ghci"><code>ghci&gt; groupBy ((==) `on` (&gt; 0)) values
+[[-4.3,-2.4,-1.2],[0.4,2.3,5.9,10.5,29.1,5.3],[-2.4,-14.5],[2.9,2.3]]</code></pre>
+<p>Very readable indeed! You can read it out loud: Group this by
+equality on whether the elements are greater than zero.</p>
+<p>Similarly, the <code>sort</code>, <code>insert</code>,
+<code>maximum</code> and <code>minimum</code> also have their more
+general equivalents. Functions like <code>groupBy</code> take a function
+that determines when two elements are equal. <code
+class="label function">sortBy</code>, <code
+class="label function">insertBy</code>, <code
+class="label function">maximumBy</code> and <code
+class="label function">minimumBy</code> take a function that determine
+if one element is greater, smaller or equal to the other. The type
+signature of <code>sortBy</code> is
+<code>sortBy :: (a -&gt; a -&gt; Ordering) -&gt; [a] -&gt; [a]</code>.
+If you remember from before, the <code>Ordering</code> type can have a
+value of <code>LT</code>, <code>EQ</code> or <code>GT</code>.
+<code>sort</code> is the equivalent of <code>sortBy compare</code>,
+because compare just takes two elements whose type is in the
+<code>Ord</code> typeclass and returns their ordering relationship.</p>
+<p>Lists can be compared, but when they are, they are compared
+lexicographically. What if we have a list of lists and we want to sort
+it not based on the inner lists’ contents but on their lengths? Well, as
+you’ve probably guessed, we’ll use the <code>sortBy</code> function.</p>
+<pre class="haskell:ghci"><code>ghci&gt; let xs = [[5,4,5,4,4],[1,2,3],[3,5,4,3],[],[2],[2,2]]
 ghci&gt; sortBy (compare `on` length) xs
-[[],[2],[2,2],[1,2,3],[3,5,4,3],[5,4,5,4,4]]
-</pre>
-<p>Awesome! <span class="fixed">compare `on` length</span> ... man, that reads almost like real English! If you're not sure how exactly the <span class="fixed">on</span> works here, <span class="fixed">compare `on` length</span> is the equivalent of <span class="fixed">\x y -&gt; length x `compare` length y</span>. When you're dealing with <i>By</i> functions that take an equality function, you usually do <span class="fixed">(==) `on` something</span> and when you're dealing with <i>By</i> functions that take an ordering function, you usually do <span class="fixed">compare `on` something</span>.</p>
-<a name="data-char"></a><h2>Data.Char</h2>
-<img src="assets/images/modules/legochar.png" alt="lego char" class="right" width="230" height="323">
-<p>The <span class="fixed">Data.Char</span> module does what its name suggests. It exports functions that deal with characters. It's also helpful when filtering and mapping over strings because they're just lists of characters.</p>
-<p><span class="fixed">Data.Char</span> exports a bunch of predicates over characters. That is, functions that take a character and tell us whether some assumption about it is true or false. Here's what they are:</p>
-<p><span class="label function">isControl</span> checks whether a character is a control character.</p>
-<p><span class="label function">isSpace</span> checks whether a character is a white-space characters. That includes spaces, tab characters, newlines, etc.</p>
-<p><span class="label function">isLower</span> checks whether a character is lower-cased. </p>
-<p><span class="label function">isUpper</span> checks whether a character is upper-cased.</p>
-<p><span class="label function">isAlpha</span> checks whether a character is a letter.</p>
-<p><span class="label function">isAlphaNum</span> checks whether a character is a letter or a number.</p>
-<p><span class="label function">isPrint</span> checks whether a character is printable. Control characters, for instance, are not printable.</p>
-<p><span class="label function">isDigit</span> checks whether a character is a digit.</p>
-<p><span class="label function">isOctDigit</span> checks whether a character is an octal digit.</p>
-<p><span class="label function">isHexDigit</span> checks whether a character is a hex digit.</p>
-<p><span class="label function">isLetter</span> checks whether a character is a letter.</p>
-<p><span class="label function">isMark</span> checks for Unicode mark characters. Those are characters that combine with preceding letters to form letters with accents. Use this if you are French.</p>
-<p><span class="label function">isNumber</span> checks whether a character is numeric.</p>
-<p><span class="label function">isPunctuation</span> checks whether a character is punctuation.</p>
-<p><span class="label function">isSymbol</span> checks whether a character is a fancy mathematical or currency symbol.</p>
-<p><span class="label function">isSeparator</span> checks for Unicode spaces and separators.</p>
-<p><span class="label function">isAscii</span> checks whether a character falls into the first 128 characters of the Unicode character set.</p>
-<p><span class="label function">isLatin1</span> checks whether a character falls into the first 256 characters of Unicode.</p>
-<p><span class="label function">isAsciiUpper</span> checks whether a character is ASCII and upper-case.</p>
-<p><span class="label function">isAsciiLower</span> checks whether a character is ASCII and lower-case.</p>
-<p>All these predicates have a type signature of <span class="fixed">Char -&gt; Bool</span>. Most of the time you'll use this to filter out strings or something like that. For instance, let's say we're making a program that takes a username and the username can only be comprised of alphanumeric characters. We can use the <span class="fixed">Data.List</span> function <span class="fixed">all</span> in combination with the <span class="fixed">Data.Char</span> predicates to determine if the username is alright.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; all isAlphaNum "bobby283"
+[[],[2],[2,2],[1,2,3],[3,5,4,3],[5,4,5,4,4]]</code></pre>
+<p>Awesome! <code>compare `on` length</code> … man, that reads almost
+like real English! If you’re not sure how exactly the <code>on</code>
+works here, <code>compare `on` length</code> is the equivalent of
+<code>\x y -&gt; length x `compare` length y</code>. When you’re dealing
+with <em>By</em> functions that take an equality function, you usually
+do <code>(==) `on` something</code> and when you’re dealing with
+<em>By</em> functions that take an ordering function, you usually do
+<code>compare `on` something</code>.</p>
+<h2 id="data-char">Data.Char</h2>
+<p><img src="assets/images/modules/legochar.png" class="right"
+width="230" height="323" alt="lego char" /></p>
+<p>The <code>Data.Char</code> module does what its name suggests. It
+exports functions that deal with characters. It’s also helpful when
+filtering and mapping over strings because they’re just lists of
+characters.</p>
+<p><code>Data.Char</code> exports a bunch of predicates over characters.
+That is, functions that take a character and tell us whether some
+assumption about it is true or false. Here’s what they are:</p>
+<p><code class="label function">isControl</code> checks whether a
+character is a control character.</p>
+<p><code class="label function">isSpace</code> checks whether a
+character is a white-space characters. That includes spaces, tab
+characters, newlines, etc.</p>
+<p><code class="label function">isLower</code> checks whether a
+character is lower-cased.</p>
+<p><code class="label function">isUpper</code> checks whether a
+character is upper-cased.</p>
+<p><code class="label function">isAlpha</code> checks whether a
+character is a letter.</p>
+<p><code class="label function">isAlphaNum</code> checks whether a
+character is a letter or a number.</p>
+<p><code class="label function">isPrint</code> checks whether a
+character is printable. Control characters, for instance, are not
+printable.</p>
+<p><code class="label function">isDigit</code> checks whether a
+character is a digit.</p>
+<p><code class="label function">isOctDigit</code> checks whether a
+character is an octal digit.</p>
+<p><code class="label function">isHexDigit</code> checks whether a
+character is a hex digit.</p>
+<p><code class="label function">isLetter</code> checks whether a
+character is a letter.</p>
+<p><code class="label function">isMark</code> checks for Unicode mark
+characters. Those are characters that combine with preceding letters to
+form letters with accents. Use this if you are French.</p>
+<p><code class="label function">isNumber</code> checks whether a
+character is numeric.</p>
+<p><code class="label function">isPunctuation</code> checks whether a
+character is punctuation.</p>
+<p><code class="label function">isSymbol</code> checks whether a
+character is a fancy mathematical or currency symbol.</p>
+<p><code class="label function">isSeparator</code> checks for Unicode
+spaces and separators.</p>
+<p><code class="label function">isAscii</code> checks whether a
+character falls into the first 128 characters of the Unicode character
+set.</p>
+<p><code class="label function">isLatin1</code> checks whether a
+character falls into the first 256 characters of Unicode.</p>
+<p><code class="label function">isAsciiUpper</code> checks whether a
+character is ASCII and upper-case.</p>
+<p><code class="label function">isAsciiLower</code> checks whether a
+character is ASCII and lower-case.</p>
+<p>All these predicates have a type signature of
+<code>Char -&gt; Bool</code>. Most of the time you’ll use this to filter
+out strings or something like that. For instance, let’s say we’re making
+a program that takes a username and the username can only be comprised
+of alphanumeric characters. We can use the <code>Data.List</code>
+function <code>all</code> in combination with the <code>Data.Char</code>
+predicates to determine if the username is alright.</p>
+<pre class="haskell:ghci"><code>ghci&gt; all isAlphaNum &quot;bobby283&quot;
 True
-ghci&gt; all isAlphaNum "eddy the fish!"
-False
-</pre>
-<p>Kewl. In case you don't remember, <span class="fixed">all</span> takes a predicate and a list and returns <span class="fixed">True</span> only if that predicate holds for every element in the list.</p>
-<p>We can also use <span class="fixed">isSpace</span> to simulate the <span class="fixed">Data.List</span> function <span class="fixed">words</span>.
-<pre name="code" class="haskell:ghci">
-ghci&gt; words "hey folks its me"
-["hey","folks","its","me"]
-ghci&gt; groupBy ((==) `on` isSpace) "hey folks its me"
-["hey"," ","folks"," ","its"," ","me"]
-ghci&gt;
-</pre>
-<p>Hmmm, well, it kind of does what <span class="fixed">words</span> does but we're left with elements of only spaces. Hmm, whatever shall we do? I know, let's filter that sucker.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; filter (not . any isSpace) . groupBy ((==) `on` isSpace) $ "hey folks its me"
-["hey","folks","its","me"]
-</pre>
+ghci&gt; all isAlphaNum &quot;eddy the fish!&quot;
+False</code></pre>
+<p>Kewl. In case you don’t remember, <code>all</code> takes a predicate
+and a list and returns <code>True</code> only if that predicate holds
+for every element in the list.</p>
+<p>We can also use <code>isSpace</code> to simulate the
+<code>Data.List</code> function <code>words</code>.</p>
+<pre class="haskell:ghci"><code>ghci&gt; words &quot;hey folks its me&quot;
+[&quot;hey&quot;,&quot;folks&quot;,&quot;its&quot;,&quot;me&quot;]
+ghci&gt; groupBy ((==) `on` isSpace) &quot;hey folks its me&quot;
+[&quot;hey&quot;,&quot; &quot;,&quot;folks&quot;,&quot; &quot;,&quot;its&quot;,&quot; &quot;,&quot;me&quot;]
+ghci&gt;</code></pre>
+<p>Hmmm, well, it kind of does what <code>words</code> does but we’re
+left with elements of only spaces. Hmm, whatever shall we do? I know,
+let’s filter that sucker.</p>
+<pre class="haskell:ghci"><code>ghci&gt; filter (not . any isSpace) . groupBy ((==) `on` isSpace) $ &quot;hey folks its me&quot;
+[&quot;hey&quot;,&quot;folks&quot;,&quot;its&quot;,&quot;me&quot;]</code></pre>
 <p>Ah.</p>
-<p>The <span class="fixed">Data.Char</span> also exports a datatype that's kind of like <span class="fixed">Ordering</span>. The <span class="fixed">Ordering</span> type can have a value of <span class="fixed">LT</span>, <span class="fixed">EQ</span> or <span class="fixed">GT</span>. It's a sort of enumeration. It describes a few possible results that can arise from comparing two elements. The <span class="fixed">GeneralCategory</span> type is also an enumeration. It presents us with a few possible categories that a character can fall into. The main function for getting the general category of a character is <span class="fixed">generalCategory</span>. It has a type of <span class="fixed">generalCategory :: Char -&gt; GeneralCategory</span>. There are about 31 categories so we won't list them all here, but let's play around with the function.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; generalCategory ' '
+<p>The <code>Data.Char</code> also exports a datatype that’s kind of
+like <code>Ordering</code>. The <code>Ordering</code> type can have a
+value of <code>LT</code>, <code>EQ</code> or <code>GT</code>. It’s a
+sort of enumeration. It describes a few possible results that can arise
+from comparing two elements. The <code>GeneralCategory</code> type is
+also an enumeration. It presents us with a few possible categories that
+a character can fall into. The main function for getting the general
+category of a character is <code>generalCategory</code>. It has a type
+of <code>generalCategory :: Char -&gt; GeneralCategory</code>. There are
+about 31 categories so we won’t list them all here, but let’s play
+around with the function.</p>
+<pre class="haskell:ghci"><code>ghci&gt; generalCategory &#39; &#39;
 Space
-ghci&gt; generalCategory 'A'
+ghci&gt; generalCategory &#39;A&#39;
 UppercaseLetter
-ghci&gt; generalCategory 'a'
+ghci&gt; generalCategory &#39;a&#39;
 LowercaseLetter
-ghci&gt; generalCategory '.'
+ghci&gt; generalCategory &#39;.&#39;
 OtherPunctuation
-ghci&gt; generalCategory '9'
+ghci&gt; generalCategory &#39;9&#39;
 DecimalNumber
-ghci&gt; map generalCategory " \t\nA9?|"
-[Space,Control,Control,UppercaseLetter,DecimalNumber,OtherPunctuation,MathSymbol]
-</pre>
-<p>Since the <span class="fixed">GeneralCategory</span> type is part of the <span class="fixed">Eq</span> typeclass, we can also test for stuff like <span class="fixed">generalCategory c == Space</span>.</p>
-<p><span class="label function">toUpper</span> converts a character to upper-case. Spaces, numbers, and the like remain unchanged.</p>
-<p><span class="label function">toLower</span> converts a character to lower-case.</p>
-<p><span class="label function">toTitle</span> converts a character to title-case. For most characters, title-case is the same as upper-case.</p>
-<p><span class="label function">digitToInt</span> converts a character to an <span class="fixed">Int</span>. To succeed, the character must be in the ranges <span class="fixed">'0'..'9'</span>, <span class="fixed">'a'..'f'</span> or <span class="fixed">'A'..'F'</span>.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; map digitToInt "34538"
+ghci&gt; map generalCategory &quot; \t\nA9?|&quot;
+[Space,Control,Control,UppercaseLetter,DecimalNumber,OtherPunctuation,MathSymbol]</code></pre>
+<p>Since the <code>GeneralCategory</code> type is part of the
+<code>Eq</code> typeclass, we can also test for stuff like
+<code>generalCategory c == Space</code>.</p>
+<p><code class="label function">toUpper</code> converts a character to
+upper-case. Spaces, numbers, and the like remain unchanged.</p>
+<p><code class="label function">toLower</code> converts a character to
+lower-case.</p>
+<p><code class="label function">toTitle</code> converts a character to
+title-case. For most characters, title-case is the same as
+upper-case.</p>
+<p><code class="label function">digitToInt</code> converts a character
+to an <code>Int</code>. To succeed, the character must be in the ranges
+<code>'0'..'9'</code>, <code>'a'..'f'</code> or
+<code>'A'..'F'</code>.</p>
+<pre class="haskell:ghci"><code>ghci&gt; map digitToInt &quot;34538&quot;
 [3,4,5,3,8]
-ghci&gt; map digitToInt "FF85AB"
-[15,15,8,5,10,11]
-</pre>
-<p><span class="label function">intToDigit</span> is the inverse function of <span class="fixed">digitToInt</span>. It takes an <span class="fixed">Int</span> in the range of <span class="fixed">0..15</span> and converts it to a lower-case character.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; intToDigit 15
-'f'
+ghci&gt; map digitToInt &quot;FF85AB&quot;
+[15,15,8,5,10,11]</code></pre>
+<p><code class="label function">intToDigit</code> is the inverse
+function of <code>digitToInt</code>. It takes an <code>Int</code> in the
+range of <code>0..15</code> and converts it to a lower-case
+character.</p>
+<pre class="haskell:ghci"><code>ghci&gt; intToDigit 15
+&#39;f&#39;
 ghci&gt; intToDigit 5
-'5'
-</pre>
-<p>The <span class="label function">ord</span> and <span class="fixed">chr</span> functions convert characters to their corresponding numbers and vice versa:</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; ord 'a'
+&#39;5&#39;</code></pre>
+<p>The <code class="label function">ord</code> and <code>chr</code>
+functions convert characters to their corresponding numbers and vice
+versa:</p>
+<pre class="haskell:ghci"><code>ghci&gt; ord &#39;a&#39;
 97
 ghci&gt; chr 97
-'a'
-ghci&gt; map ord "abcdefgh"
-[97,98,99,100,101,102,103,104]
-</pre>
-<p>The difference between the <span class="fixed">ord</span> values of two characters is equal to how far apart they are in the Unicode table.</p><p>The Caesar cipher is a primitive method of encoding messages by shifting each character in them by a fixed number of positions in the alphabet. We can easily create a sort of Caesar cipher of our own, only we won't constrict ourselves to the alphabet.</p>
-<pre name="code" class="haskell:hs">
-encode :: Int -&gt; String -&gt; String
+&#39;a&#39;
+ghci&gt; map ord &quot;abcdefgh&quot;
+[97,98,99,100,101,102,103,104]</code></pre>
+<p>The difference between the <code>ord</code> values of two characters
+is equal to how far apart they are in the Unicode table.</p>
+<p>The Caesar cipher is a primitive method of encoding messages by
+shifting each character in them by a fixed number of positions in the
+alphabet. We can easily create a sort of Caesar cipher of our own, only
+we won’t constrict ourselves to the alphabet.</p>
+<pre class="haskell:hs"><code>encode :: Int -&gt; String -&gt; String
 encode shift msg =
     let ords = map ord msg
         shifted = map (+ shift) ords
-    in  map chr shifted
-</pre>
-<p>Here, we first convert the string to a list of numbers. Then we add the shift amount to each number before converting the list of numbers back to characters. If you're a composition cowboy, you could write the body of this function as <span class="fixed">map (chr . (+ shift) . ord) msg</span>. Let's try encoding a few messages.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; encode 3 "Heeeeey"
-"Khhhhh|"
-ghci&gt; encode 4 "Heeeeey"
-"Liiiii}"
-ghci&gt; encode 1 "abcd"
-"bcde"
-ghci&gt; encode 5 "Marry Christmas! Ho ho ho!"
-"Rfww~%Hmwnxyrfx&amp;%Mt%mt%mt&amp;"
-</pre>
-<p>That's encoded alright. Decoding a message is basically just shifting it back by the number of places it was shifted by in the first place.</p>
-<pre name="code" class="haskell:hs">
-decode :: Int -&gt; String -&gt; String
-decode shift msg = encode (negate shift) msg
-</pre>
-<pre name="code" class="haskell:ghci">
-ghci&gt; encode 3 "Im a little teapot"
-"Lp#d#olwwoh#whdsrw"
-ghci&gt; decode 3 "Lp#d#olwwoh#whdsrw"
-"Im a little teapot"
-ghci&gt; decode 5 . encode 5 $ "This is a sentence"
-"This is a sentence"
-</pre>
-<a name="data-map"></a><h2>Data.Map</h2>
-<p>Association lists (also called dictionaries) are lists that are used to store key-value pairs where ordering doesn't matter. For instance, we might use an association list to store phone numbers, where phone numbers would be the values and people's names would be the keys. We don't care in which order they're stored, we just want to get the right phone number for the right person.</p>
-<p>The most obvious way to represent association lists in Haskell would be by having a list of pairs. The first component in the pair would be the key, the second component the value. Here's an example of an association list with phone numbers:</p>
-<pre name="code" class="haskell:hs">
-phoneBook =
-    [("amelia","555-2938")
-    ,("freya","452-2928")
-    ,("isabella","493-2928")
-    ,("neil","205-2928")
-    ,("roald","939-8282")
-    ,("tenzing","853-2492")
-    ]
-</pre>
-<p>Despite this seemingly odd indentation, this is just a list of pairs of strings. The most common task when dealing with association lists is looking up some value by key. Let's make a function that looks up some value given a key.</p>
-<pre name="code" class="haskell:hs">
-findKey :: (Eq k) =&gt; k -&gt; [(k,v)] -&gt; v
-findKey key xs = snd . head . filter (\(k,v) -&gt; key == k) $ xs
-</pre>
-<p>Pretty simple. The function that takes a key and a list, filters the list so that only matching keys remain, gets the first key-value that matches and returns the value. But what happens if the key we're looking for isn't in the association list? Hmm. Here, if a key isn't in the association list, we'll end up trying to get the head of an empty list, which throws a runtime error. However, we should avoid making our programs so easy to crash, so let's use the <span class="fixed">Maybe</span> data type. If we don't find the key, we'll return a <span class="fixed">Nothing</span>. If we find it, we'll return <span class="fixed">Just something</span>, where something is the value corresponding to that key.</p>
-<pre name="code" class="haskell:hs">
-findKey :: (Eq k) =&gt; k -&gt; [(k,v)] -&gt; Maybe v
+    in  map chr shifted</code></pre>
+<p>Here, we first convert the string to a list of numbers. Then we add
+the shift amount to each number before converting the list of numbers
+back to characters. If you’re a composition cowboy, you could write the
+body of this function as <code>map (chr . (+ shift) . ord) msg</code>.
+Let’s try encoding a few messages.</p>
+<pre class="haskell:ghci"><code>ghci&gt; encode 3 &quot;Heeeeey&quot;
+&quot;Khhhhh|&quot;
+ghci&gt; encode 4 &quot;Heeeeey&quot;
+&quot;Liiiii}&quot;
+ghci&gt; encode 1 &quot;abcd&quot;
+&quot;bcde&quot;
+ghci&gt; encode 5 &quot;Marry Christmas! Ho ho ho!&quot;
+&quot;Rfww~%Hmwnxyrfx&amp;%Mt%mt%mt&amp;&quot;</code></pre>
+<p>That’s encoded alright. Decoding a message is basically just shifting
+it back by the number of places it was shifted by in the first
+place.</p>
+<pre class="haskell:hs"><code>decode :: Int -&gt; String -&gt; String
+decode shift msg = encode (negate shift) msg</code></pre>
+<pre class="haskell:ghci"><code>ghci&gt; encode 3 &quot;Im a little teapot&quot;
+&quot;Lp#d#olwwoh#whdsrw&quot;
+ghci&gt; decode 3 &quot;Lp#d#olwwoh#whdsrw&quot;
+&quot;Im a little teapot&quot;
+ghci&gt; decode 5 . encode 5 $ &quot;This is a sentence&quot;
+&quot;This is a sentence&quot;</code></pre>
+<h2 id="data-map">Data.Map</h2>
+<p>Association lists (also called dictionaries) are lists that are used
+to store key-value pairs where ordering doesn’t matter. For instance, we
+might use an association list to store phone numbers, where phone
+numbers would be the values and people’s names would be the keys. We
+don’t care in which order they’re stored, we just want to get the right
+phone number for the right person.</p>
+<p>The most obvious way to represent association lists in Haskell would
+be by having a list of pairs. The first component in the pair would be
+the key, the second component the value. Here’s an example of an
+association list with phone numbers:</p>
+<pre class="haskell:hs"><code>phoneBook =
+    [(&quot;amelia&quot;,&quot;555-2938&quot;)
+    ,(&quot;freya&quot;,&quot;452-2928&quot;)
+    ,(&quot;isabella&quot;,&quot;493-2928&quot;)
+    ,(&quot;neil&quot;,&quot;205-2928&quot;)
+    ,(&quot;roald&quot;,&quot;939-8282&quot;)
+    ,(&quot;tenzing&quot;,&quot;853-2492&quot;)
+    ]</code></pre>
+<p>Despite this seemingly odd indentation, this is just a list of pairs
+of strings. The most common task when dealing with association lists is
+looking up some value by key. Let’s make a function that looks up some
+value given a key.</p>
+<pre class="haskell:hs"><code>findKey :: (Eq k) =&gt; k -&gt; [(k,v)] -&gt; v
+findKey key xs = snd . head . filter (\(k,v) -&gt; key == k) $ xs</code></pre>
+<p>Pretty simple. The function that takes a key and a list, filters the
+list so that only matching keys remain, gets the first key-value that
+matches and returns the value. But what happens if the key we’re looking
+for isn’t in the association list? Hmm. Here, if a key isn’t in the
+association list, we’ll end up trying to get the head of an empty list,
+which throws a runtime error. However, we should avoid making our
+programs so easy to crash, so let’s use the <code>Maybe</code> data
+type. If we don’t find the key, we’ll return a <code>Nothing</code>. If
+we find it, we’ll return <code>Just something</code>, where something is
+the value corresponding to that key.</p>
+<pre class="haskell:hs"><code>findKey :: (Eq k) =&gt; k -&gt; [(k,v)] -&gt; Maybe v
 findKey key [] = Nothing
 findKey key ((k,v):xs) = if key == k
                             then Just v
-                            else findKey key xs
-</pre>
-<p>Look at the type declaration. It takes a key that can be equated, an association list and then it maybe produces a value. Sounds about right.</p>
-<p>This is a textbook recursive function that operates on a list. Edge case, splitting a list into a head and a tail, recursive calls, they're all there. This is the classic fold pattern, so let's see how this would be implemented as a fold.</p>
-<pre name="code" class="haskell:hs">
-findKey :: (Eq k) =&gt; k -&gt; [(k,v)] -&gt; Maybe v
-findKey key = foldr (\(k,v) acc -&gt; if key == k then Just v else acc) Nothing
-</pre>
-<div class="hintbox"><em>Note:</em> It's usually better to use folds for this standard list recursion pattern instead of explicitly writing the recursion because they're easier to read and identify. Everyone knows it's a fold when they see the <span class="fixed">foldr</span> call, but it takes some more thinking to read explicit recursion.</div>
-<pre name="code" class="haskell:ghci">
-ghci&gt; findKey "tenzing" phoneBook
-Just "853-2492"
-ghci&gt; findKey "amelia" phoneBook
-Just "555-2938"
-ghci&gt; findKey "christopher" phoneBook
-Nothing
-</pre>
-<img src="assets/images/modules/legomap.png" alt="legomap" class="left" width="214" height="240">
-<p>Works like a charm! If we have the friend's phone number, we <span class="fixed">Just</span> get the number, otherwise we get <span class="fixed">Nothing</span>.</p>
-<p>We just implemented the <span class="fixed">lookup</span> function from <span class="fixed">Data.List</span>. If we want to find the corresponding value to a key, we have to traverse all the elements of the list until we find it. The <span class="fixed">Data.Map</span> module offers association lists that are much faster (because they're internally implemented with trees) and also it provides a lot of utility functions. From now on, we'll say we're working with maps instead of association lists.</p>
-<p>Because <span class="fixed">Data.Map</span> exports functions that clash with the <span class="fixed">Prelude</span> and <span class="fixed">Data.List</span> ones, we'll do a qualified import.
-<pre name="code" class="haskell:hs">
-import qualified Data.Map as Map
-</pre>
-<p>Put this import statement into a script and then load the script via GHCI.</p>
-<p>Let's go ahead and see what <span class="fixed">Data.Map</span> has in store for us! Here's the basic rundown of its functions.</p>
-<p>The <span class="label function">fromList</span> function takes an association list (in the form of a list) and returns a map with the same associations.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; Map.fromList [("amelia","555-2938"),("freya","452-2928"),("neil","205-2928")]
-fromList [("amelia","555-2938"),("freya","452-2928"),("neil","205-2928")]
+                            else findKey key xs</code></pre>
+<p>Look at the type declaration. It takes a key that can be equated, an
+association list and then it maybe produces a value. Sounds about
+right.</p>
+<p>This is a textbook recursive function that operates on a list. Edge
+case, splitting a list into a head and a tail, recursive calls, they’re
+all there. This is the classic fold pattern, so let’s see how this would
+be implemented as a fold.</p>
+<pre class="haskell:hs"><code>findKey :: (Eq k) =&gt; k -&gt; [(k,v)] -&gt; Maybe v
+findKey key = foldr (\(k,v) acc -&gt; if key == k then Just v else acc) Nothing</code></pre>
+<div class="hintbox">
+<p><strong>Note:</strong> It’s usually better to use folds for this
+standard list recursion pattern instead of explicitly writing the
+recursion because they’re easier to read and identify. Everyone knows
+it’s a fold when they see the <code>foldr</code> call, but it takes some
+more thinking to read explicit recursion.</p>
+</div>
+<pre class="haskell:ghci"><code>ghci&gt; findKey &quot;tenzing&quot; phoneBook
+Just &quot;853-2492&quot;
+ghci&gt; findKey &quot;amelia&quot; phoneBook
+Just &quot;555-2938&quot;
+ghci&gt; findKey &quot;christopher&quot; phoneBook
+Nothing</code></pre>
+<p><img src="assets/images/modules/legomap.png" class="left" width="214"
+height="240" alt="legomap" /></p>
+<p>Works like a charm! If we have the friend’s phone number, we
+<code>Just</code> get the number, otherwise we get
+<code>Nothing</code>.</p>
+<p>We just implemented the <code>lookup</code> function from
+<code>Data.List</code>. If we want to find the corresponding value to a
+key, we have to traverse all the elements of the list until we find it.
+The <code>Data.Map</code> module offers association lists that are much
+faster (because they’re internally implemented with trees) and also it
+provides a lot of utility functions. From now on, we’ll say we’re
+working with maps instead of association lists.</p>
+<p>Because <code>Data.Map</code> exports functions that clash with the
+<code>Prelude</code> and <code>Data.List</code> ones, we’ll do a
+qualified import.</p>
+<pre class="haskell:hs"><code>import qualified Data.Map as Map</code></pre>
+<p>Put this import statement into a script and then load the script via
+GHCI.</p>
+<p>Let’s go ahead and see what <code>Data.Map</code> has in store for
+us! Here’s the basic rundown of its functions.</p>
+<p>The <code class="label function">fromList</code> function takes an
+association list (in the form of a list) and returns a map with the same
+associations.</p>
+<pre class="haskell:ghci"><code>ghci&gt; Map.fromList [(&quot;amelia&quot;,&quot;555-2938&quot;),(&quot;freya&quot;,&quot;452-2928&quot;),(&quot;neil&quot;,&quot;205-2928&quot;)]
+fromList [(&quot;amelia&quot;,&quot;555-2938&quot;),(&quot;freya&quot;,&quot;452-2928&quot;),(&quot;neil&quot;,&quot;205-2928&quot;)]
 ghci&gt; Map.fromList [(1,2),(3,4),(3,2),(5,5)]
-fromList [(1,2),(3,2),(5,5)]
-</pre>
-<p>If there are duplicate keys in the original association list, the duplicates are just discarded. This is the type signature of <span class="fixed">fromList</span></p>
-<pre name="code" class="haskell:hs">
-Map.fromList :: (Ord k) =&gt; [(k, v)] -&gt; Map.Map k v
-</pre>
-<p>It says that it takes a list of pairs of type <span class="fixed">k</span> and <span class="fixed">v</span> and returns a map that maps from keys of type <span class="fixed">k</span> to type <span class="fixed">v</span>. Notice that when we were doing association lists with normal lists, the keys only had to be equatable (their type belonging to the <span class="fixed">Eq</span> typeclass) but now they have to be orderable. That's an essential constraint in the <span class="fixed">Data.Map</span> module. It needs the keys to be orderable so it can arrange them in a tree.</p>
-<p>You should always use <span class="fixed">Data.Map</span> for key-value associations unless you have keys that aren't part of the <span class="fixed">Ord</span> typeclass.</p>
-<p><span class="label function">empty</span> represents an empty map. It takes no arguments, it just returns an empty map.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; Map.empty
-fromList []
-</pre>
-<p><span class="label function">insert</span> takes a key, a value and a map and returns a new map that's just like the old one, only with the key and value inserted.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; Map.empty
+fromList [(1,2),(3,2),(5,5)]</code></pre>
+<p>If there are duplicate keys in the original association list, the
+duplicates are just discarded. This is the type signature of
+<code>fromList</code></p>
+<pre class="haskell:hs"><code>Map.fromList :: (Ord k) =&gt; [(k, v)] -&gt; Map.Map k v</code></pre>
+<p>It says that it takes a list of pairs of type <code>k</code> and
+<code>v</code> and returns a map that maps from keys of type
+<code>k</code> to type <code>v</code>. Notice that when we were doing
+association lists with normal lists, the keys only had to be equatable
+(their type belonging to the <code>Eq</code> typeclass) but now they
+have to be orderable. That’s an essential constraint in the
+<code>Data.Map</code> module. It needs the keys to be orderable so it
+can arrange them in a tree.</p>
+<p>You should always use <code>Data.Map</code> for key-value
+associations unless you have keys that aren’t part of the
+<code>Ord</code> typeclass.</p>
+<p><code class="label function">empty</code> represents an empty map. It
+takes no arguments, it just returns an empty map.</p>
+<pre class="haskell:ghci"><code>ghci&gt; Map.empty
+fromList []</code></pre>
+<p><code class="label function">insert</code> takes a key, a value and a
+map and returns a new map that’s just like the old one, only with the
+key and value inserted.</p>
+<pre class="haskell:ghci"><code>ghci&gt; Map.empty
 fromList []
 ghci&gt; Map.insert 3 100 Map.empty
 fromList [(3,100)]
 ghci&gt; Map.insert 5 600 (Map.insert 4 200 ( Map.insert 3 100  Map.empty))
 fromList [(3,100),(4,200),(5,600)]
 ghci&gt; Map.insert 5 600 . Map.insert 4 200 . Map.insert 3 100 $ Map.empty
-fromList [(3,100),(4,200),(5,600)]
-</pre>
-<p>We can implement our own <span class="fixed">fromList</span> by using the empty map, <span class="fixed">insert</span> and a fold. Watch:</p>
-<pre name="code" class="haskell:ghci">
-fromList' :: (Ord k) =&gt; [(k,v)] -&gt; Map.Map k v
-fromList' = foldr (\(k,v) acc -&gt; Map.insert k v acc) Map.empty
-</pre>
-<p>It's a pretty straightforward fold. We start of with an empty map and we fold it up from the right, inserting the key value pairs into the accumulator as we go along.</p>
-<p><span class="label function">null</span> checks if a map is empty.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; Map.null Map.empty
+fromList [(3,100),(4,200),(5,600)]</code></pre>
+<p>We can implement our own <code>fromList</code> by using the empty
+map, <code>insert</code> and a fold. Watch:</p>
+<pre class="haskell:ghci"><code>fromList&#39; :: (Ord k) =&gt; [(k,v)] -&gt; Map.Map k v
+fromList&#39; = foldr (\(k,v) acc -&gt; Map.insert k v acc) Map.empty</code></pre>
+<p>It’s a pretty straightforward fold. We start of with an empty map and
+we fold it up from the right, inserting the key value pairs into the
+accumulator as we go along.</p>
+<p><code class="label function">null</code> checks if a map is
+empty.</p>
+<pre class="haskell:ghci"><code>ghci&gt; Map.null Map.empty
 True
 ghci&gt; Map.null $ Map.fromList [(2,3),(5,5)]
-False
-</pre>
-<p><span class="label function">size</span> reports the size of a map.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; Map.size Map.empty
+False</code></pre>
+<p><code class="label function">size</code> reports the size of a
+map.</p>
+<pre class="haskell:ghci"><code>ghci&gt; Map.size Map.empty
 0
 ghci&gt; Map.size $ Map.fromList [(2,4),(3,3),(4,2),(5,4),(6,4)]
-5
-</pre>
-<p><span class="label function">singleton</span> takes a key and a value and creates a map that has exactly one mapping.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; Map.singleton 3 9
+5</code></pre>
+<p><code class="label function">singleton</code> takes a key and a value
+and creates a map that has exactly one mapping.</p>
+<pre class="haskell:ghci"><code>ghci&gt; Map.singleton 3 9
 fromList [(3,9)]
 ghci&gt; Map.insert 5 9 $ Map.singleton 3 9
-fromList [(3,9),(5,9)]
-</pre>
-<p><span class="label function">lookup</span> works like the <span class="fixed">Data.List</span> <span class="fixed">lookup</span>, only it operates on maps. It returns <span class="fixed">Just something</span> if it finds something for the key and <span class="fixed">Nothing</span> if it doesn't.</p>
-<p><span class="label function">member</span> is a predicate that takes a key and a map and reports whether the key is in the map or not.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; Map.member 3 $ Map.fromList [(3,6),(4,3),(6,9)]
+fromList [(3,9),(5,9)]</code></pre>
+<p><code class="label function">lookup</code> works like the
+<code>Data.List</code> <code>lookup</code>, only it operates on maps. It
+returns <code>Just something</code> if it finds something for the key
+and <code>Nothing</code> if it doesn’t.</p>
+<p><code class="label function">member</code> is a predicate that takes
+a key and a map and reports whether the key is in the map or not.</p>
+<pre class="haskell:ghci"><code>ghci&gt; Map.member 3 $ Map.fromList [(3,6),(4,3),(6,9)]
 True
 ghci&gt; Map.member 3 $ Map.fromList [(2,5),(4,5)]
-False
-</pre>
-<p><span class="label function">map</span> and <span class="label function">filter</span> work much like their list equivalents.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; Map.map (*100) $ Map.fromList [(1,1),(2,4),(3,9)]
+False</code></pre>
+<p><code class="label function">map</code> and <code
+class="label function">filter</code> work much like their list
+equivalents.</p>
+<pre class="haskell:ghci"><code>ghci&gt; Map.map (*100) $ Map.fromList [(1,1),(2,4),(3,9)]
 fromList [(1,100),(2,400),(3,900)]
-ghci&gt; Map.filter isUpper $ Map.fromList [(1,'a'),(2,'A'),(3,'b'),(4,'B')]
-fromList [(2,'A'),(4,'B')]
-</pre>
-<p><span class="label function">toList</span> is the inverse of <span class="fixed">fromList</span>.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; Map.toList . Map.insert 9 2 $ Map.singleton 4 3
-[(4,3),(9,2)]
-</pre>
-<p><span class="label function">keys</span> and <span class="label function">elems</span> return lists of keys and values respectively. <span class="fixed">keys</span> is the equivalent of <span class="fixed">map fst . Map.toList</span> and <span class="fixed">elems</span> is the equivalent of <span class="fixed">map snd . Map.toList</span>.</p>
-<p><span class="label function">fromListWith</span> is a cool little function. It acts like <span class="fixed">fromList</span>, only it doesn't discard duplicate keys but it uses a function supplied to it to decide what to do with them. Let's say that a friend can have several numbers and we have an association list set up like this.</p>
-<pre name="code" class="haskell:hs">
-phoneBook =
-    [("amelia","555-2938")
-    ,("amelia","342-2492")
-    ,("freya","452-2928")
-    ,("isabella","493-2928")
-    ,("isabella","943-2929")
-    ,("isabella","827-9162")
-    ,("neil","205-2928")
-    ,("roald","939-8282")
-    ,("tenzing","853-2492")
-    ,("tenzing","555-2111")
-    ]
-</pre>
-<p>Now if we just use <span class="fixed">fromList</span> to put that into a map, we'll lose a few numbers! So here's what we'll do:</p>
-<pre name="code" class="haskell:hs">
-phoneBookToMap :: (Ord k) =&gt; [(k, String)] -&gt; Map.Map k String
-phoneBookToMap xs = Map.fromListWith (\number1 number2 -&gt; number1 ++ ", " ++ number2) xs
-</pre>
-<pre name="code" class="haskell:hs">
-ghci&gt; Map.lookup "isabella" $ phoneBookToMap phoneBook
-"827-9162, 943-2929, 493-2928"
-ghci&gt; Map.lookup "roald" $ phoneBookToMap phoneBook
-"939-8282"
-ghci&gt; Map.lookup "amelia" $ phoneBookToMap phoneBook
-"342-2492, 555-2938"
-</pre>
-<p>If a duplicate key is found, the function we pass is used to combine the values of those keys into some other value. We could also first make all the values in the association list singleton lists and then we can use <span class="fixed">++</span> to combine the numbers.</p>
-<pre name="code" class="haskell:hs">
-phoneBookToMap :: (Ord k) =&gt; [(k, a)] -&gt; Map.Map k [a]
-phoneBookToMap xs = Map.fromListWith (++) $ map (\(k,v) -&gt; (k,[v])) xs
-</pre>
-<pre name="code" class="haskell:ghci">
-ghci&gt; Map.lookup "isabella" $ phoneBookToMap phoneBook
-["827-9162","943-2929","493-2928"]
-</pre>
-<p>Pretty neat! Another use case is if we're making a map from an association list of numbers and when a duplicate key is found, we want the biggest value for the key to be kept.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; Map.fromListWith max [(2,3),(2,5),(2,100),(3,29),(3,22),(3,11),(4,22),(4,15)]
-fromList [(2,100),(3,29),(4,22)]
-</pre>
+ghci&gt; Map.filter isUpper $ Map.fromList [(1,&#39;a&#39;),(2,&#39;A&#39;),(3,&#39;b&#39;),(4,&#39;B&#39;)]
+fromList [(2,&#39;A&#39;),(4,&#39;B&#39;)]</code></pre>
+<p><code class="label function">toList</code> is the inverse of
+<code>fromList</code>.</p>
+<pre class="haskell:ghci"><code>ghci&gt; Map.toList . Map.insert 9 2 $ Map.singleton 4 3
+[(4,3),(9,2)]</code></pre>
+<p><code class="label function">keys</code> and <code
+class="label function">elems</code> return lists of keys and values
+respectively. <code>keys</code> is the equivalent of
+<code>map fst . Map.toList</code> and <code>elems</code> is the
+equivalent of <code>map snd . Map.toList</code>.</p>
+<p><code class="label function">fromListWith</code> is a cool little
+function. It acts like <code>fromList</code>, only it doesn’t discard
+duplicate keys but it uses a function supplied to it to decide what to
+do with them. Let’s say that a friend can have several numbers and we
+have an association list set up like this.</p>
+<pre class="haskell:hs"><code>phoneBook =
+    [(&quot;amelia&quot;,&quot;555-2938&quot;)
+    ,(&quot;amelia&quot;,&quot;342-2492&quot;)
+    ,(&quot;freya&quot;,&quot;452-2928&quot;)
+    ,(&quot;isabella&quot;,&quot;493-2928&quot;)
+    ,(&quot;isabella&quot;,&quot;943-2929&quot;)
+    ,(&quot;isabella&quot;,&quot;827-9162&quot;)
+    ,(&quot;neil&quot;,&quot;205-2928&quot;)
+    ,(&quot;roald&quot;,&quot;939-8282&quot;)
+    ,(&quot;tenzing&quot;,&quot;853-2492&quot;)
+    ,(&quot;tenzing&quot;,&quot;555-2111&quot;)
+    ]</code></pre>
+<p>Now if we just use <code>fromList</code> to put that into a map,
+we’ll lose a few numbers! So here’s what we’ll do:</p>
+<pre class="haskell:hs"><code>phoneBookToMap :: (Ord k) =&gt; [(k, String)] -&gt; Map.Map k String
+phoneBookToMap xs = Map.fromListWith (\number1 number2 -&gt; number1 ++ &quot;, &quot; ++ number2) xs</code></pre>
+<pre class="haskell:hs"><code>ghci&gt; Map.lookup &quot;isabella&quot; $ phoneBookToMap phoneBook
+&quot;827-9162, 943-2929, 493-2928&quot;
+ghci&gt; Map.lookup &quot;roald&quot; $ phoneBookToMap phoneBook
+&quot;939-8282&quot;
+ghci&gt; Map.lookup &quot;amelia&quot; $ phoneBookToMap phoneBook
+&quot;342-2492, 555-2938&quot;</code></pre>
+<p>If a duplicate key is found, the function we pass is used to combine
+the values of those keys into some other value. We could also first make
+all the values in the association list singleton lists and then we can
+use <code>++</code> to combine the numbers.</p>
+<pre class="haskell:hs"><code>phoneBookToMap :: (Ord k) =&gt; [(k, a)] -&gt; Map.Map k [a]
+phoneBookToMap xs = Map.fromListWith (++) $ map (\(k,v) -&gt; (k,[v])) xs</code></pre>
+<pre class="haskell:ghci"><code>ghci&gt; Map.lookup &quot;isabella&quot; $ phoneBookToMap phoneBook
+[&quot;827-9162&quot;,&quot;943-2929&quot;,&quot;493-2928&quot;]</code></pre>
+<p>Pretty neat! Another use case is if we’re making a map from an
+association list of numbers and when a duplicate key is found, we want
+the biggest value for the key to be kept.</p>
+<pre class="haskell:ghci"><code>ghci&gt; Map.fromListWith max [(2,3),(2,5),(2,100),(3,29),(3,22),(3,11),(4,22),(4,15)]
+fromList [(2,100),(3,29),(4,22)]</code></pre>
 <p>Or we could choose to add together values on the same keys.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; Map.fromListWith (+) [(2,3),(2,5),(2,100),(3,29),(3,22),(3,11),(4,22),(4,15)]
-fromList [(2,108),(3,62),(4,37)]
-</pre>
-<p><span class="label function">insertWith</span> is to <span class="fixed">insert</span> what <span class="fixed">fromListWith</span> is to <span class="fixed">fromList</span>. It inserts a key-value pair into a map, but if that map already contains the key, it uses the function passed to it to determine what to do.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; Map.insertWith (+) 3 100 $ Map.fromList [(3,4),(5,103),(6,339)]
-fromList [(3,104),(5,103),(6,339)]
-</pre>
-<p>These were just a few functions from <span class="fixed">Data.Map</span>. You can see a complete list of functions in the <a href="https://hackage.haskell.org/package/containers/docs/Data-Map.html">documentation</a>.</p>
-<a name="data-set"></a><h2>Data.Set</h2>
-<img src="assets/images/modules/legosets.png" alt="legosets" class="right" width="150" height="236">
-<p>The <span class="fixed">Data.Set</span> module offers us, well, sets. Like sets from mathematics. Sets are kind of like a cross between lists and maps. All the elements in a set are unique. And because they're internally implemented with trees (much like maps in <span class="fixed">Data.Map</span>), they're ordered. Checking for membership, inserting, deleting, etc. is much faster than doing the same thing with lists. The most common operation when dealing with sets are inserting into a set, checking for membership and converting a set to a list.</p>
-<p>Because the names in <span class="fixed">Data.Set</span> clash with a lot of <span class="fixed">Prelude</span> and <span class="fixed">Data.List</span> names, we do a qualified import.</p>
+<pre class="haskell:ghci"><code>ghci&gt; Map.fromListWith (+) [(2,3),(2,5),(2,100),(3,29),(3,22),(3,11),(4,22),(4,15)]
+fromList [(2,108),(3,62),(4,37)]</code></pre>
+<p><code class="label function">insertWith</code> is to
+<code>insert</code> what <code>fromListWith</code> is to
+<code>fromList</code>. It inserts a key-value pair into a map, but if
+that map already contains the key, it uses the function passed to it to
+determine what to do.</p>
+<pre class="haskell:ghci"><code>ghci&gt; Map.insertWith (+) 3 100 $ Map.fromList [(3,4),(5,103),(6,339)]
+fromList [(3,104),(5,103),(6,339)]</code></pre>
+<p>These were just a few functions from <code>Data.Map</code>. You can
+see a complete list of functions in the <a
+href="https://hackage.haskell.org/package/containers/docs/Data-Map.html">documentation</a>.</p>
+<h2 id="data-set">Data.Set</h2>
+<p><img src="assets/images/modules/legosets.png" class="right"
+width="150" height="236" alt="legosets" /></p>
+<p>The <code>Data.Set</code> module offers us, well, sets. Like sets
+from mathematics. Sets are kind of like a cross between lists and maps.
+All the elements in a set are unique. And because they’re internally
+implemented with trees (much like maps in <code>Data.Map</code>),
+they’re ordered. Checking for membership, inserting, deleting, etc. is
+much faster than doing the same thing with lists. The most common
+operation when dealing with sets are inserting into a set, checking for
+membership and converting a set to a list.</p>
+<p>Because the names in <code>Data.Set</code> clash with a lot of
+<code>Prelude</code> and <code>Data.List</code> names, we do a qualified
+import.</p>
 <p>Put this import statement in a script:</p>
-<pre name="code" class="haskell:ghci">
-import qualified Data.Set as Set
-</pre>
+<pre class="haskell:ghci"><code>import qualified Data.Set as Set</code></pre>
 <p>And then load the script via GHCI.</p>
-<p>Let's say we have two pieces of text. We want to find out which characters were used in both of them.</p>
-<pre name="code" class="haskell:ghci">
-text1 = "I just had an anime dream. Anime... Reality... Are they so different?"
-text2 = "The old man left his garbage can out and now his trash is all over my lawn!"
-</pre>
-<p>
-The <span class="label function">fromList</span> function works much like you would expect. It takes a list and converts it into a set.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; let set1 = Set.fromList text1
+<p>Let’s say we have two pieces of text. We want to find out which
+characters were used in both of them.</p>
+<pre class="haskell:ghci"><code>text1 = &quot;I just had an anime dream. Anime... Reality... Are they so different?&quot;
+text2 = &quot;The old man left his garbage can out and now his trash is all over my lawn!&quot;</code></pre>
+<p>The <code class="label function">fromList</code> function works much
+like you would expect. It takes a list and converts it into a set.</p>
+<pre class="haskell:ghci"><code>ghci&gt; let set1 = Set.fromList text1
 ghci&gt; let set2 = Set.fromList text2
 ghci&gt; set1
-fromList " .?AIRadefhijlmnorstuy"
+fromList &quot; .?AIRadefhijlmnorstuy&quot;
 ghci&gt; set2
-fromList " !Tabcdefghilmnorstuvwy"
-</pre>
-<p>As you can see, the items are ordered and each element is unique. Now let's use the <span class="label function">intersection</span> function to see which elements they both share.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; Set.intersection set1 set2
-fromList " adefhilmnorstuy"
-</pre>
-<p>We can use the <span class="label function">difference</span> function to see which letters are in the first set but aren't in the second one and vice versa.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; Set.difference set1 set2
-fromList ".?AIRj"
+fromList &quot; !Tabcdefghilmnorstuvwy&quot;</code></pre>
+<p>As you can see, the items are ordered and each element is unique. Now
+let’s use the <code class="label function">intersection</code> function
+to see which elements they both share.</p>
+<pre class="haskell:ghci"><code>ghci&gt; Set.intersection set1 set2
+fromList &quot; adefhilmnorstuy&quot;</code></pre>
+<p>We can use the <code class="label function">difference</code>
+function to see which letters are in the first set but aren’t in the
+second one and vice versa.</p>
+<pre class="haskell:ghci"><code>ghci&gt; Set.difference set1 set2
+fromList &quot;.?AIRj&quot;
 ghci&gt; Set.difference set2 set1
-fromList "!Tbcgvw"
-</pre>
-<p>Or we can see all the unique letters used in both sentences by using <span class="label function">union</span>.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; Set.union set1 set2
-fromList " !.?AIRTabcdefghijlmnorstuvwy"
-</pre>
-<p>The <span class="label function">null</span>, <span class="label function">size</span>, <span class="label function">member</span>, <span class="label function">empty</span>, <span class="label function">singleton</span>, <span class="label function">insert</span> and <span class="label function">delete</span> functions all work like you'd expect them to.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; Set.null Set.empty
+fromList &quot;!Tbcgvw&quot;</code></pre>
+<p>Or we can see all the unique letters used in both sentences by using
+<code class="label function">union</code>.</p>
+<pre class="haskell:ghci"><code>ghci&gt; Set.union set1 set2
+fromList &quot; !.?AIRTabcdefghijlmnorstuvwy&quot;</code></pre>
+<p>The <code class="label function">null</code>, <code
+class="label function">size</code>, <code
+class="label function">member</code>, <code
+class="label function">empty</code>, <code
+class="label function">singleton</code>, <code
+class="label function">insert</code> and <code
+class="label function">delete</code> functions all work like you’d
+expect them to.</p>
+<pre class="haskell:ghci"><code>ghci&gt; Set.null Set.empty
 True
 ghci&gt; Set.null $ Set.fromList [3,4,5,5,4,3]
 False
@@ -764,54 +1100,76 @@ fromList [1,3,4,8,9]
 ghci&gt; Set.insert 8 $ Set.fromList [5..10]
 fromList [5,6,7,8,9,10]
 ghci&gt; Set.delete 4 $ Set.fromList [3,4,5,4,3,4,5]
-fromList [3,5]
-</pre>
-<p>We can also check for subsets or proper subset. Set A is a subset of set B if B contains all the elements that A does. Set A is a proper subset of set B if B contains all the elements that A does but has more elements.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; Set.fromList [2,3,4] `Set.isSubsetOf` Set.fromList [1,2,3,4,5]
+fromList [3,5]</code></pre>
+<p>We can also check for subsets or proper subset. Set A is a subset of
+set B if B contains all the elements that A does. Set A is a proper
+subset of set B if B contains all the elements that A does but has more
+elements.</p>
+<pre class="haskell:ghci"><code>ghci&gt; Set.fromList [2,3,4] `Set.isSubsetOf` Set.fromList [1,2,3,4,5]
 True
 ghci&gt; Set.fromList [1,2,3,4,5] `Set.isSubsetOf` Set.fromList [1,2,3,4,5]
 True
 ghci&gt; Set.fromList [1,2,3,4,5] `Set.isProperSubsetOf` Set.fromList [1,2,3,4,5]
 False
 ghci&gt; Set.fromList [2,3,4,8] `Set.isSubsetOf` Set.fromList [1,2,3,4,5]
-False
-</pre>
-<p>We can also <span class="label function">map</span> over sets and <span class="label function">filter</span> them.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; Set.filter odd $ Set.fromList [3,4,5,6,7,2,3,4]
+False</code></pre>
+<p>We can also <code class="label function">map</code> over sets and
+<code class="label function">filter</code> them.</p>
+<pre class="haskell:ghci"><code>ghci&gt; Set.filter odd $ Set.fromList [3,4,5,6,7,2,3,4]
 fromList [3,5,7]
 ghci&gt; Set.map (+1) $ Set.fromList [3,4,5,6,7,2,3,4]
-fromList [3,4,5,6,7,8]
-</pre>
-<p>Sets are often used to weed a list of duplicates from a list by first making it into a set with <span class="fixed">fromList</span> and then converting it back to a list with <span class="label function">toList</span>. The <span class="fixed">Data.List</span> function <span class="fixed">nub</span> already does that, but weeding out duplicates for large lists is much faster if you cram them into a set and then convert them back to a list than using <span class="fixed">nub</span>. But using <span class="fixed">nub</span> only requires the type of the list's elements to be part of the <span class="fixed">Eq</span> typeclass, whereas if you want to cram elements into a set, the type of the list has to be in <span class="fixed">Ord</span>.</p>
-<pre name="code" class="haskell:ghci">
-ghci&gt; let setNub xs = Set.toList $ Set.fromList xs
-ghci&gt; setNub "HEY WHATS CRACKALACKIN"
-" ACEHIKLNRSTWY"
-ghci&gt; nub "HEY WHATS CRACKALACKIN"
-"HEY WATSCRKLIN"
-</pre>
-<p><span class="fixed">setNub</span> is generally faster than <span class="fixed">nub</span> on big lists but as you can see, <span class="fixed">nub</span> preserves the ordering of the list's elements, while <span class="fixed">setNub</span> does not.</p>
-<a name="making-our-own-modules"></a><h2>Making our own modules</h2>
-<img src="assets/images/modules/making_modules.png" alt="making modules" class="right" width="345" height="224">
-<p>We've looked at some cool modules so far, but how do we make our own module? Almost every programming language enables you to split your code up into several files and Haskell is no different. When making programs, it's good practice to take functions and types that work towards a similar purpose and put them in a module. That way, you can easily reuse those functions in other programs by just importing your module.</p>
-<p>Let's see how we can make our own modules by making a little module that provides some functions for calculating the volume and area of a few geometrical objects. We'll start by creating a file called <span class="fixed">Geometry.hs</span>.</p>
-<p>We say that a module <i>exports</i> functions. What that means is that when I import a module, I can use the functions that it exports. It can define functions that its functions call internally, but we can only see and use the ones that it exports.</p>
-<p>At the beginning of a module, we specify the module name. If we have a file called <span class="fixed">Geometry.hs</span>, then we should name our module <span class="fixed">Geometry</span>. Then, we specify the functions that it exports and after that, we can start writing the functions. So we'll start with this.</p>
-<pre name="code" class="haskell:ghci">
-module Geometry
+fromList [3,4,5,6,7,8]</code></pre>
+<p>Sets are often used to weed a list of duplicates from a list by first
+making it into a set with <code>fromList</code> and then converting it
+back to a list with <code class="label function">toList</code>. The
+<code>Data.List</code> function <code>nub</code> already does that, but
+weeding out duplicates for large lists is much faster if you cram them
+into a set and then convert them back to a list than using
+<code>nub</code>. But using <code>nub</code> only requires the type of
+the list’s elements to be part of the <code>Eq</code> typeclass, whereas
+if you want to cram elements into a set, the type of the list has to be
+in <code>Ord</code>.</p>
+<pre class="haskell:ghci"><code>ghci&gt; let setNub xs = Set.toList $ Set.fromList xs
+ghci&gt; setNub &quot;HEY WHATS CRACKALACKIN&quot;
+&quot; ACEHIKLNRSTWY&quot;
+ghci&gt; nub &quot;HEY WHATS CRACKALACKIN&quot;
+&quot;HEY WATSCRKLIN&quot;</code></pre>
+<p><code>setNub</code> is generally faster than <code>nub</code> on big
+lists but as you can see, <code>nub</code> preserves the ordering of the
+list’s elements, while <code>setNub</code> does not.</p>
+<h2 id="making-our-own-modules">Making our own modules</h2>
+<p><img src="assets/images/modules/making_modules.png" class="right"
+width="345" height="224" alt="making modules" /></p>
+<p>We’ve looked at some cool modules so far, but how do we make our own
+module? Almost every programming language enables you to split your code
+up into several files and Haskell is no different. When making programs,
+it’s good practice to take functions and types that work towards a
+similar purpose and put them in a module. That way, you can easily reuse
+those functions in other programs by just importing your module.</p>
+<p>Let’s see how we can make our own modules by making a little module
+that provides some functions for calculating the volume and area of a
+few geometrical objects. We’ll start by creating a file called
+<code>Geometry.hs</code>.</p>
+<p>We say that a module <em>exports</em> functions. What that means is
+that when I import a module, I can use the functions that it exports. It
+can define functions that its functions call internally, but we can only
+see and use the ones that it exports.</p>
+<p>At the beginning of a module, we specify the module name. If we have
+a file called <code>Geometry.hs</code>, then we should name our module
+<code>Geometry</code>. Then, we specify the functions that it exports
+and after that, we can start writing the functions. So we’ll start with
+this.</p>
+<pre class="haskell:ghci"><code>module Geometry
 ( sphereVolume
 , sphereArea
 , cubeVolume
 , cubeArea
 , cuboidArea
 , cuboidVolume
-) where
-</pre>
-<p>As you can see, we'll be doing areas and volumes for spheres, cubes and cuboids. Let's go ahead and define our functions then:</p>
-<pre name="code" class="haskell:ghci">
-module Geometry
+) where</code></pre>
+<p>As you can see, we’ll be doing areas and volumes for spheres, cubes
+and cuboids. Let’s go ahead and define our functions then:</p>
+<pre class="haskell:ghci"><code>module Geometry
 ( sphereVolume
 , sphereArea
 , cubeVolume
@@ -839,20 +1197,40 @@ cuboidArea :: Float -&gt; Float -&gt; Float -&gt; Float
 cuboidArea a b c = rectangleArea a b * 2 + rectangleArea a c * 2 + rectangleArea c b * 2
 
 rectangleArea :: Float -&gt; Float -&gt; Float
-rectangleArea a b = a * b
-</pre>
-<p>Pretty standard geometry right here. There are a few things to take note of though. Because a cube is only a special case of a cuboid, we defined its area and volume by treating it as a cuboid whose sides are all of the same length. We also defined a helper function called <span class="fixed">rectangleArea</span>, which calculates a rectangle's area based on the lenghts of its sides. It's rather trivial because it's just multiplication. Notice that we used it in our functions in the module (namely <span class="fixed">cuboidArea</span> and <span class="fixed">cuboidVolume</span>) but we didn't export it! Because we want our module to just present functions for dealing with three-dimensional objects, we used <span class="fixed">rectangleArea</span> but we didn't export it.</p>
-<p>When making a module, we usually export only those functions that act as a sort of interface to our module so that the implementation is hidden. If someone is using our <span class="fixed">Geometry</span> module, they don't have to concern themselves with functions that we don't export. We can decide to change those functions completely or delete them in a newer version (we could delete <span class="fixed">rectangleArea</span> and just use <span class="fixed">*</span> instead) and no one will mind because we weren't exporting them in the first place.</p>
+rectangleArea a b = a * b</code></pre>
+<p>Pretty standard geometry right here. There are a few things to take
+note of though. Because a cube is only a special case of a cuboid, we
+defined its area and volume by treating it as a cuboid whose sides are
+all of the same length. We also defined a helper function called
+<code>rectangleArea</code>, which calculates a rectangle’s area based on
+the lenghts of its sides. It’s rather trivial because it’s just
+multiplication. Notice that we used it in our functions in the module
+(namely <code>cuboidArea</code> and <code>cuboidVolume</code>) but we
+didn’t export it! Because we want our module to just present functions
+for dealing with three-dimensional objects, we used
+<code>rectangleArea</code> but we didn’t export it.</p>
+<p>When making a module, we usually export only those functions that act
+as a sort of interface to our module so that the implementation is
+hidden. If someone is using our <code>Geometry</code> module, they don’t
+have to concern themselves with functions that we don’t export. We can
+decide to change those functions completely or delete them in a newer
+version (we could delete <code>rectangleArea</code> and just use
+<code>*</code> instead) and no one will mind because we weren’t
+exporting them in the first place.</p>
 <p>To use our module, we just do:</p>
-<pre name="code" class="haskell:ghci">
-import Geometry
-</pre>
-<p><span class="fixed">Geometry.hs</span> has to be in the same folder that the program that's importing it is in, though.</p>
-<p>Modules can also have a hierarchical structure. Each module can have a number of submodules and they can have submodules of their own. Let's section these functions off so that <span class="fixed">Geometry</span> is a module that has three submodules, one for each type of object.</p>
-<p>First, we'll make a folder called <span class="fixed">Geometry</span>. Mind the capital G. In it, we'll place three files: <span class="fixed">Sphere.hs</span>, <span class="fixed">Cuboid.hs</span>, and <span class="fixed">Cube.hs</span>. Here's what the files will contain:</p>
-<p><span class="fixed">Sphere.hs</span></p>
-<pre name="code" class="haskell:ghci">
-module Geometry.Sphere
+<pre class="haskell:ghci"><code>import Geometry</code></pre>
+<p><code>Geometry.hs</code> has to be in the same folder that the
+program that’s importing it is in, though.</p>
+<p>Modules can also have a hierarchical structure. Each module can have
+a number of submodules and they can have submodules of their own. Let’s
+section these functions off so that <code>Geometry</code> is a module
+that has three submodules, one for each type of object.</p>
+<p>First, we’ll make a folder called <code>Geometry</code>. Mind the
+capital G. In it, we’ll place three files: <code>Sphere.hs</code>,
+<code>Cuboid.hs</code>, and <code>Cube.hs</code>. Here’s what the files
+will contain:</p>
+<p><code>Sphere.hs</code></p>
+<pre class="haskell:ghci"><code>module Geometry.Sphere
 ( volume
 , area
 ) where
@@ -861,11 +1239,9 @@ volume :: Float -&gt; Float
 volume radius = (4.0 / 3.0) * pi * (radius ^ 3)
 
 area :: Float -&gt; Float
-area radius = 4 * pi * (radius ^ 2)
-</pre>
-<p><span class="fixed">Cuboid.hs</span></p>
-<pre name="code" class="haskell:ghci">
-module Geometry.Cuboid
+area radius = 4 * pi * (radius ^ 2)</code></pre>
+<p><code>Cuboid.hs</code></p>
+<pre class="haskell:ghci"><code>module Geometry.Cuboid
 ( volume
 , area
 ) where
@@ -877,11 +1253,9 @@ area :: Float -&gt; Float -&gt; Float -&gt; Float
 area a b c = rectangleArea a b * 2 + rectangleArea a c * 2 + rectangleArea c b * 2
 
 rectangleArea :: Float -&gt; Float -&gt; Float
-rectangleArea a b = a * b
-</pre>
-<p><span class="fixed">Cube.hs</span></p>
-<pre name="code" class="haskell:ghci">
-module Geometry.Cube
+rectangleArea a b = a * b</code></pre>
+<p><code>Cube.hs</code></p>
+<pre class="haskell:ghci"><code>module Geometry.Cube
 ( volume
 , area
 ) where
@@ -892,21 +1266,36 @@ volume :: Float -&gt; Float
 volume side = Cuboid.volume side side side
 
 area :: Float -&gt; Float
-area side = Cuboid.area side side side
-</pre>
-<p>Alright! So first is <span class="fixed">Geometry.Sphere</span>. Notice how we placed it in a folder called <span class="fixed">Geometry</span> and then defined the module name as <span class="fixed">Geometry.Sphere</span>. We did the same for the cuboid. Also notice how in all three submodules, we defined functions with the same names. We can do this because they're separate modules. We want to use functions from <span class="fixed">Geometry.Cuboid</span> in <span class="fixed">Geometry.Cube</span> but we can't just straight up do <span class="fixed">import Geometry.Cuboid</span> because it exports functions with the same names as <span class="fixed">Geometry.Cube</span>. That's why we do a qualified import and all is well.</p>
-<p>So now if we're in a file that's on the same level as the <span class="fixed">Geometry</span> folder, we can do, say:</p>
-<pre name="code" class="haskell:ghci">
-import Geometry.Sphere
-</pre>
-<p>And then we can call <span class="fixed">area</span> and <span class="fixed">volume</span> and they'll give us the area and volume for a sphere. And if we want to juggle two or more of these modules, we have to do qualified imports because they export functions with the same names. So we just do something like:</p>
-<pre name="code" class="haskell:ghci">
-import qualified Geometry.Sphere as Sphere
+area side = Cuboid.area side side side</code></pre>
+<p>Alright! So first is <code>Geometry.Sphere</code>. Notice how we
+placed it in a folder called <code>Geometry</code> and then defined the
+module name as <code>Geometry.Sphere</code>. We did the same for the
+cuboid. Also notice how in all three submodules, we defined functions
+with the same names. We can do this because they’re separate modules. We
+want to use functions from <code>Geometry.Cuboid</code> in
+<code>Geometry.Cube</code> but we can’t just straight up do
+<code>import Geometry.Cuboid</code> because it exports functions with
+the same names as <code>Geometry.Cube</code>. That’s why we do a
+qualified import and all is well.</p>
+<p>So now if we’re in a file that’s on the same level as the
+<code>Geometry</code> folder, we can do, say:</p>
+<pre class="haskell:ghci"><code>import Geometry.Sphere</code></pre>
+<p>And then we can call <code>area</code> and <code>volume</code> and
+they’ll give us the area and volume for a sphere. And if we want to
+juggle two or more of these modules, we have to do qualified imports
+because they export functions with the same names. So we just do
+something like:</p>
+<pre class="haskell:ghci"><code>import qualified Geometry.Sphere as Sphere
 import qualified Geometry.Cuboid as Cuboid
-import qualified Geometry.Cube as Cube
-</pre>
-<p>And then we can call <span class="fixed">Sphere.area</span>, <span class="fixed">Sphere.volume</span>, <span class="fixed">Cuboid.area</span>, etc. and each will calculate the area or volume for their corresponding object.</p>
-<p>The next time you find yourself writing a file that's really big and has a lot of functions, try to see which functions serve some common purpose and then see if you can put them in their own module. You'll be able to just import your module the next time you're writing a program that requires some of the same functionality.</p>
+import qualified Geometry.Cube as Cube</code></pre>
+<p>And then we can call <code>Sphere.area</code>,
+<code>Sphere.volume</code>, <code>Cuboid.area</code>, etc. and each will
+calculate the area or volume for their corresponding object.</p>
+<p>The next time you find yourself writing a file that’s really big and
+has a lot of functions, try to see which functions serve some common
+purpose and then see if you can put them in their own module. You’ll be
+able to just import your module the next time you’re writing a program
+that requires some of the same functionality.</p>
                 <div class="footdiv">
                 <ul>
                     <li style="text-align:left">

--- a/markdown/generated_html/making-our-own-types-and-typeclasses.html
+++ b/markdown/generated_html/making-our-own-types-and-typeclasses.html
@@ -782,9 +782,9 @@ types</em> I mean like fully applied types like
 <code>Map Int String</code> or if we’re dealin’ with one of them
 polymorphic functions, <code>[a]</code> or
 <code>(Ord a) =&gt; Maybe a</code> and stuff. And like, sometimes me and
-my buddies say that <code>Maybe</code> is a type, but we don’t mean that,
-cause every idiot knows <code>Maybe</code> is a type constructor. When I
-apply an extra type to <code>Maybe</code>, like
+my buddies say that <code>Maybe</code> is a type, but we don’t mean
+that, cause every idiot knows <code>Maybe</code> is a type constructor.
+When I apply an extra type to <code>Maybe</code>, like
 <code>Maybe String</code>, then I have a concrete type. You know, values
 can only have types that are concrete types! So in conclusion, live
 fast, love hard and don’t let anybody else use your comb!</p>

--- a/markdown/generated_html/modules.html
+++ b/markdown/generated_html/modules.html
@@ -157,7 +157,7 @@ the rows and vice versa.</p>
 <pre class="haskell:ghci"><code>ghci&gt; transpose [[1,2,3],[4,5,6],[7,8,9]]
 [[1,4,7],[2,5,8],[3,6,9]]
 ghci&gt; transpose [&quot;hey&quot;,&quot;there&quot;,&quot;folks&quot;]
-[&quot;htg&quot;,&quot;ehu&quot;,&quot;yey&quot;,&quot;rs&quot;,&quot;e&quot;]</code></pre>
+[&quot;htf&quot;,&quot;eho&quot;,&quot;yel&quot;,&quot;rk&quot;,&quot;es&quot;]</code></pre>
 <p>Say we have the polynomials <em>3x<sup>2</sup> + 5x + 9</em>,
 <em>10x<sup>3</sup> + 9</em> and <em>8x<sup>3</sup> + 5x<sup>2</sup> + x
 - 1</em> and we want to add them together. We can use the lists
@@ -984,8 +984,8 @@ equivalent of <code>map snd . Map.toList</code>.</p>
 <p><code class="label function">fromListWith</code> is a cool little
 function. It acts like <code>fromList</code>, only it doesn’t discard
 duplicate keys but it uses a function supplied to it to decide what to
-do with them. Let’s say that a friend can have several numbers and we have
-an association list set up like this.</p>
+do with them. Let’s say that a friend can have several numbers and we
+have an association list set up like this.</p>
 <pre class="haskell:hs"><code>phoneBook =
     [(&quot;amelia&quot;,&quot;555-2938&quot;)
     ,(&quot;amelia&quot;,&quot;342-2492&quot;)

--- a/markdown/source_md/modules.md
+++ b/markdown/source_md/modules.md
@@ -126,7 +126,7 @@ If you look at a list of lists as a 2D matrix, the columns become the rows and v
 ghci> transpose [[1,2,3],[4,5,6],[7,8,9]]
 [[1,4,7],[2,5,8],[3,6,9]]
 ghci> transpose ["hey","there","folks"]
-["htg","ehu","yey","rs","e"]
+["htf","eho","yel","rk","es"]
 ```
 
 Say we have the polynomials *3x^2^ + 5x + 9*, *10x^3^ + 9* and *8x^3^ + 5x^2^ + x - 1* and we want to add them together.


### PR DESCRIPTION
The change in PR #51 from `transpose ["hey","there","guys"]` to `transpose ["hey","there","folks"]` does not address the corresponding change to the function's output. This pull request fixes that.

An update has been performed in the `source_md/modules.md` file, where `["htg","ehu","yey","rs","e"]` has been changed to `["htf","eho","yel","rk","es"]`. I then executed `generate.sh`, which produced the expected updates to `modules.html` in the `generated_html` folder, as well as formatting updates to `making-our-own-types-and-typeclasses.html`. Lastly, the updated html files were copied to the `docs` folder.