### PR TITLE
remove extra word, regen html

### DIFF
--- a/markdown/generated_html/input-and-output.html
+++ b/markdown/generated_html/input-and-output.html
@@ -2169,7 +2169,7 @@ ghci&gt; head []
 <p><img src="assets/images/input-and-output/police.png" class="left"
 width="241" height="328"
 alt="Stop right there, criminal scum! Nobody breaks the law on my watch! Now pay your fine or it’s off to jail." /></p>
-<p>Pure code can throw exceptions, but it they can only be caught in the
+<p>Pure code can throw exceptions, but they can only be caught in the
 I/O part of our code (when we’re inside a <em>do</em> block that goes
 into <code>main</code>). That’s because you don’t know when (or if)
 anything will be evaluated in pure code, because it is lazy and doesn’t

--- a/markdown/generated_html/making-our-own-types-and-typeclasses.html
+++ b/markdown/generated_html/making-our-own-types-and-typeclasses.html
@@ -782,9 +782,9 @@ types</em> I mean like fully applied types like
 <code>Map Int String</code> or if we’re dealin’ with one of them
 polymorphic functions, <code>[a]</code> or
 <code>(Ord a) =&gt; Maybe a</code> and stuff. And like, sometimes me and
-my buddies say that <code>Maybe</code> is a type, but we don’t mean that,
-cause every idiot knows <code>Maybe</code> is a type constructor. When I
-apply an extra type to <code>Maybe</code>, like
+my buddies say that <code>Maybe</code> is a type, but we don’t mean
+that, cause every idiot knows <code>Maybe</code> is a type constructor.
+When I apply an extra type to <code>Maybe</code>, like
 <code>Maybe String</code>, then I have a concrete type. You know, values
 can only have types that are concrete types! So in conclusion, live
 fast, love hard and don’t let anybody else use your comb!</p>

--- a/markdown/generated_html/modules.html
+++ b/markdown/generated_html/modules.html
@@ -984,8 +984,8 @@ equivalent of <code>map snd . Map.toList</code>.</p>
 <p><code class="label function">fromListWith</code> is a cool little
 function. It acts like <code>fromList</code>, only it doesn’t discard
 duplicate keys but it uses a function supplied to it to decide what to
-do with them. Let’s say that a friend can have several numbers and we have
-an association list set up like this.</p>
+do with them. Let’s say that a friend can have several numbers and we
+have an association list set up like this.</p>
 <pre class="haskell:hs"><code>phoneBook =
     [(&quot;amelia&quot;,&quot;555-2938&quot;)
     ,(&quot;amelia&quot;,&quot;342-2492&quot;)

--- a/markdown/source_md/input-and-output.md
+++ b/markdown/source_md/input-and-output.md
@@ -1,4 +1,4 @@
-# Input and Output 
+# Input and Output
 
 ![poor dog](assets/images/input-and-output/dognap.png){.right width=261 height=382}
 
@@ -2067,7 +2067,7 @@ ghci> head []
 
 ![Stop right there, criminal scum! Nobody breaks the law on my watch! Now pay your fine or it's off to jail.](assets/images/input-and-output/police.png){width=241 height=328 .left}
 
-Pure code can throw exceptions, but it they can only be caught in the I/O part of our code (when we're inside a *do* block that goes into `main`).
+Pure code can throw exceptions, but they can only be caught in the I/O part of our code (when we're inside a *do* block that goes into `main`).
 That's because you don't know when (or if) anything will be evaluated in pure code, because it is lazy and doesn't have a well-defined order of execution, whereas I/O code does.
 
 Earlier, we talked about how we should spend as little time as possible in the I/O part of our program.
@@ -2307,4 +2307,3 @@ This is kind of similar to *try-catch* blocks of other languages, where you can 
 Now you know how to deal with I/O exceptions!
 Throwing exceptions from pure code and dealing with them hasn't been covered here, mainly because, like we said, Haskell offers much better ways to indicate errors than reverting to I/O to catch them.
 Even when glueing together I/O actions that might fail, I prefer to have their type be something like `IO (Either a b)`, meaning that they're normal I/O actions but the result that they yield when performed is of type `Either a b`, meaning it's either `Left a` or `Right b`.
-


### PR DESCRIPTION
Changed input-and-output.md, regenerated html
This resulted in changed paragraph flow in a few other html files. (Why?)
