### PR TITLE
feat: remove illogical sentence

### DIFF
--- a/markdown/source_md/types-and-typeclasses.md
+++ b/markdown/source_md/types-and-typeclasses.md
@@ -424,7 +424,7 @@ It has a type declaration of `fromIntegral :: (Num b, Integral a) => a -> b`.
 From its type signature we see that it takes an integral number and turns it into a more general number.
 That's useful when you want integral and floating point types to work together nicely.
 For instance, the `length` function has a type declaration of `length :: [a] -> Int` instead of having a more general type of `(Num b) => length :: [a] -> b`.
-Anyway, if we try to get a length of a list and then add it to `3.2`, we'll get an error because we tried to add together an `Int` and a floating point number.
+If we try to get a length of a list and then add it to `3.2`, we'll get an error because we tried to add together an `Int` and a floating point number.
 So to get around this, we do `fromIntegral (length [1,2,3,4]) + 3.2` and it all works out.
 
 Notice that `fromIntegral` has several class constraints in its type signature.

--- a/markdown/source_md/types-and-typeclasses.md
+++ b/markdown/source_md/types-and-typeclasses.md
@@ -424,7 +424,6 @@ It has a type declaration of `fromIntegral :: (Num b, Integral a) => a -> b`.
 From its type signature we see that it takes an integral number and turns it into a more general number.
 That's useful when you want integral and floating point types to work together nicely.
 For instance, the `length` function has a type declaration of `length :: [a] -> Int` instead of having a more general type of `(Num b) => length :: [a] -> b`.
-I think that's there for historical reasons or something, although in my opinion, it's pretty stupid.
 Anyway, if we try to get a length of a list and then add it to `3.2`, we'll get an error because we tried to add together an `Int` and a floating point number.
 So to get around this, we do `fromIntegral (length [1,2,3,4]) + 3.2` and it all works out.
 


### PR DESCRIPTION
The type signature of `length` returns an Int for a good reason and that is to ensure that any code using that function can rely on the result being an integral number. Logically speaking, lists can't contain a fractional number of elements, so this is probably not for historical reasons nor is it stupid. I think removing this sentence altogether would make more sense.