### PR TITLE
Fix transpose example issue in modules chapter

### DIFF
--- a/docs/modules.html
+++ b/docs/modules.html
@@ -93,7 +93,7 @@ ghci&gt; intercalate [0,0,0] [[1,2,3],[4,5,6],[7,8,9]]
 ghci&gt; transpose [[1,2,3],[4,5,6],[7,8,9]]
 [[1,4,7],[2,5,8],[3,6,9]]
 ghci&gt; transpose ["hey","there","folks"]
-["htg","ehu","yey","rs","e"]
+["htf","eho","yel","rk","es"]
 </pre>
 <p>Say we have the polynomials <i>3x<sup>2</sup> + 5x + 9</i>, <i>10x<sup>3</sup> + 9</i> and <i>8x<sup>3</sup> + 5x<sup>2</sup> + x - 1</i> and we want to add them together. We can use the lists <span class="fixed">[0,3,5,9]</span>, <span class="fixed">[10,0,0,9]</span> and <span class="fixed">[8,5,1,-1]</span> to represent them in Haskell. Now, to add them, all we have to do is this:</p>
 <pre name="code" class="haskell:ghci">


### PR DESCRIPTION
There is an issue in the `transpose` example in chapter `Modules`.

Currently on the book:
```hs
transpose ["hey","there","folks"]
["htg","ehu","yey","rs","e"]
```

Correct:
```hs
transpose ["hey","there","folks"]
["htf","eho","yel","rk","es"]
```