### PR TITLE
Minor refactoring of generate.sh

### DIFF
--- a/markdown/generate.sh
+++ b/markdown/generate.sh
@@ -13,8 +13,8 @@ do
 
     title[$i]=$(sed -n '/^# /s/# //p;' $sourcemd | sed 's/{.*//; s/ *$//g')
 
-    chnum=$(($i + 1))
-    if [[ $chnum -ge 10 ]];
+    chnum=$((i + 1))
+    if ((chnum >= 10))
     then
         sp=" "
     else
@@ -30,7 +30,7 @@ done
 
 for i in ${!filename[@]}
 do
-    if (($i <= 0))
+    if ((i <= 0))
     then
         prev_title=
         prev_filename=
@@ -39,7 +39,7 @@ do
         prev_title="${title[$prev]}"
         prev_filename=${filename[$prev]}
     fi
-    if (($i >= ${#filename[@]} - 1))
+    if ((i >= ${#filename[@]} - 1))
     then
         next_title=
         next_filename=

--- a/markdown/generate.sh
+++ b/markdown/generate.sh
@@ -10,8 +10,8 @@ cp source_md/chapters_head.md $chapterfile
 for i in ${!filename[@]}
 do
     sourcemd=source_md/${filename[$i]}.md
-    
-    title[$i]=$(sed -n '/^# /s/# //p;' $sourcemd | sed 's/{.*//' | sed 's/ *$//g')
+
+    title[$i]=$(sed -n '/^# /s/# //p;' $sourcemd | sed 's/{.*//; s/ *$//g')
 
     chnum=$(($i + 1))
     if [[ $chnum -ge 10 ]];
@@ -21,11 +21,11 @@ do
         sp="  "
     fi
 
-    sed -n '/^#\{1,2\} /p' $sourcemd \
-        | sed "s/^#  *\(.*[^ ]\) *{.*/$chnum.$sp[\1](${filename[$i]}.html)/" \
-        | sed "s/^#  *\(.*[^ ]\) */$chnum.$sp[\1](${filename[$i]}.html)/" \
-        | sed "s/^##  *\(.*[^ ]\) *{ *#\(.*\)}/    * [\1](${filename[$i]}.html\#\2)/" \
-        >>$chapterfile
+    grep '^#\{1,2\} ' $sourcemd \
+        | sed "s/^#  *\(.*[^ ]\) *{.*/$chnum.$sp[\1](${filename[$i]}.html)/;
+               s/^#  *\(.*[^ ]\) */$chnum.$sp[\1](${filename[$i]}.html)/;
+               s/^##  *\(.*[^ ]\) *{ *#\(.*\)}/    * [\1](${filename[$i]}.html\#\2)/" \
+        >> $chapterfile
 done
 
 for i in ${!filename[@]}
@@ -48,13 +48,13 @@ do
         next_title="${title[$next]}"
         next_filename=${filename[$next]}
     fi
-    
+
     pandoc -d config/pandoc-defaults.yml --template=config/template.html \
         -V footdiv=true -V title="${title[$i]}" \
         --metadata title="${title[$i]}$titlesuffix" \
         -V prev_title="$prev_title" -V prev_filename=$prev_filename \
         -V next_title="$next_title" -V next_filename=$next_filename \
-        -o generated_html/${filename[$i]}.html source_md/${filename[$i]}.md   
+        -o generated_html/${filename[$i]}.html source_md/${filename[$i]}.md
 done
 
 cat source_md/chapters_foot.md >>$chapterfile

--- a/markdown/generated_html/functors-applicative-functors-and-monoids.html
+++ b/markdown/generated_html/functors-applicative-functors-and-monoids.html
@@ -412,7 +412,7 @@ holds.</p>
     fmap f (Just x) = Just (f x)
     fmap f Nothing = Nothing</code></pre>
 <p>We imagine that <code>id</code> plays the role of the <code>f</code>
-parameter in the implementation. We see that if wee <code>fmap id</code>
+parameter in the implementation. We see that if we <code>fmap id</code>
 over <code>Just x</code>, the result will be <code>Just (id x)</code>,
 and because <code>id</code> just returns its parameter, we can deduce
 that <code>Just (id x)</code> equals <code>Just x</code>. So now we know

--- a/markdown/generated_html/higher-order-functions.html
+++ b/markdown/generated_html/higher-order-functions.html
@@ -155,12 +155,10 @@ the <code>subtract</code> function like so:
 instead of binding it to a name with a <em>let</em> or passing it to
 another function?</p>
 <pre class="haskell:hs"><code>ghci&gt; multThree 3 4
-&lt;interactive&gt;:1:0:
-    No instance for (Show (t -&gt; t))
-      arising from a use of `print&#39; at &lt;interactive&gt;:1:0-12
-    Possible fix: add an instance declaration for (Show (t -&gt; t))
-    In the expression: print it
-    In a &#39;do&#39; expression: print it</code></pre>
+&lt;interactive&gt;:1:1: error: [GHC-39999]
+    • No instance for ‘Show (a0 -&gt; a0)’ arising from a use of ‘print’
+        (maybe you haven&#39;t applied a function to enough arguments?)
+    • In a stmt of an interactive GHCi command: print it</code></pre>
 <p>GHCI is telling us that the expression produced a function of type
 <code>a -&gt; a</code> but it doesn’t know how to print it to the
 screen. Functions aren’t instances of the <code>Show</code> typeclass,

--- a/markdown/generated_html/introduction.html
+++ b/markdown/generated_html/introduction.html
@@ -56,7 +56,9 @@ person such as yourself will be able to follow along and learn
 Haskell.</p>
 <p>The channel #haskell on the Libera.Chat network is a great place to
 ask questions if you’re feeling stuck. People there are extremely nice,
-patient and understanding to newbies.</p>
+patient and understanding to newbies. If IRC it not your cup of tea, <a
+href="https://discourse.haskell.org">https://discourse.haskell.org</a>
+is a popular community forum with a section for learners.</p>
 <p>I failed to learn Haskell approximately 2 times before finally
 grasping it because it all just seemed too weird to me and I didn’t get
 it. But then once it just “clicked” and after getting over that initial

--- a/markdown/generated_html/making-our-own-types-and-typeclasses.html
+++ b/markdown/generated_html/making-our-own-types-and-typeclasses.html
@@ -1012,8 +1012,8 @@ Empty .++ ys = ys
 ghci&gt; let b = 6 :-: 7 :-: Empty
 ghci&gt; a .++ b
 (:-:) 3 ((:-:) 4 ((:-:) 5 ((:-:) 6 ((:-:) 7 Empty))))</code></pre>
-<p>Nice. Is nice. If we wanted, we could implement all of the functions
-that operate on lists on our own list type.</p>
+<p>Nice. If we wanted, we could implement all of the functions that
+operate on lists on our own list type.</p>
 <p>Notice how we pattern matched on <code>(x :-: xs)</code>. That works
 because pattern matching is actually about matching constructors. We can
 match on <code>:-:</code> because it is a constructor for our own list

--- a/markdown/generated_html/starting-out.html
+++ b/markdown/generated_html/starting-out.html
@@ -96,8 +96,10 @@ ghci&gt; &quot;hello&quot; == &quot;hello&quot;
 True</code></pre>
 <p>What about doing <code>5 + "llama"</code> or <code>5 == True</code>?
 Well, if we try the first snippet, we get a big scary error message!</p>
-<pre class="haskell: ghci"><code>• No instance for (Num String) arising from a use of ‘+’
-    • In the expression: 5 + &quot;llama&quot;
+<pre class="haskell: ghci"><code>&lt;interactive&gt;:1:1: error: [GHC-39999]
+    • No instance for ‘Num String’ arising from the literal ‘5’
+    • In the first argument of ‘(+)’, namely ‘5’
+      In the expression: 5 + &quot;llama&quot;
       In an equation for ‘it’: it = 5 + &quot;llama&quot;</code></pre>
 <p>Yikes! What GHCI is telling us here is that <code>"llama"</code> is
 not a number and so it doesn’t know how to add it to 5. Even if it
@@ -113,6 +115,13 @@ later. Note: you can do <code>5 + 4.0</code> because <code>5</code> is
 sneaky and can act like an integer or a floating-point number.
 <code>4.0</code> can’t act like an integer, so <code>5</code> is the one
 that has to adapt.</p>
+<div class="hintbox">
+<p><strong>Note:</strong> GHC errors are all assigned unique identifiers
+such as <code>GHC-39999</code> above. Whenever you are stuck with a
+stubborn error, you can look it up at <a
+href="https://errors.haskell.org/">https://errors.haskell.org/</a> to
+learn typical causes and solutions.</p>
+</div>
 <p>You may not have known it but we’ve been using functions now all
 along. For instance, <code>*</code> is a function that takes two numbers
 and multiplies them. As you’ve seen, we call it by sandwiching it
@@ -664,8 +673,9 @@ let’s use that instead. Instead of surrounding the vectors with square
 brackets, we use parentheses: <code>[(1,2),(8,11),(4,5)]</code>. What if
 we tried to make a shape like <code>[(1,2),(8,11,5),(4,5)]</code>? Well,
 we’d get this error:</p>
-<pre class="haskell: ghci"><code>• Couldn&#39;t match expected type ‘(a, b)’
-                  with actual type ‘(a0, b0, c0)’
+<pre class="haskell: ghci"><code>&lt;interactive&gt;:1:8: error: [GHC-83865]
+    • Couldn&#39;t match expected type: (a, b)
+                  with actual type: (a0, b0, c0)
     • In the expression: (8, 11, 5)
       In the expression: [(1, 2), (8, 11, 5), (4, 5)]
       In an equation for ‘it’: it = [(1, 2), (8, 11, 5), (4, 5)]

--- a/markdown/generated_html/types-and-typeclasses.html
+++ b/markdown/generated_html/types-and-typeclasses.html
@@ -402,13 +402,12 @@ into a more general number. That’s useful when you want integral and
 floating point types to work together nicely. For instance, the
 <code>length</code> function has a type declaration of
 <code>length :: [a] -&gt; Int</code> instead of having a more general
-type of <code>(Num b) =&gt; length :: [a] -&gt; b</code>. I think that’s
-there for historical reasons or something, although in my opinion, it’s
-pretty stupid. Anyway, if we try to get a length of a list and then add
-it to <code>3.2</code>, we’ll get an error because we tried to add
-together an <code>Int</code> and a floating point number. So to get
-around this, we do <code>fromIntegral (length [1,2,3,4]) + 3.2</code>
-and it all works out.</p>
+type of <code>(Num b) =&gt; length :: [a] -&gt; b</code>. If we try to
+get a length of a list and then add it to <code>3.2</code>, we’ll get an
+error because we tried to add together an <code>Int</code> and a
+floating point number. So to get around this, we do
+<code>fromIntegral (length [1,2,3,4]) + 3.2</code> and it all works
+out.</p>
 <p>Notice that <code>fromIntegral</code> has several class constraints
 in its type signature. That’s completely valid and as you can see, the
 class constraints are separated by commas inside the parentheses.</p>


### PR DESCRIPTION
I hope to get the build infrastructure in a flexible enough state eventually so that the book can be compiled into different formats (mainly, PDF and single-page HMTL)

Changes Made:
* Remove significant whitespace in generate.sh
* Give generate.sh executable permissions
* Re-run generate.sh, pushing a few previous changes to the generated html
* `sed command | sed command` -> `sed "command; command"`, unnecessary `$` in shell math  

P.S.
Right now, the filenames for the chapters are being stored in a simple text file, and the titles for the chapters are being extracted using `sed`, if that file was a YAML file, which stored the filenames and titles in a list, and the templating could use it to reference the previous/next chapters (with pandoc's `$for$`). It would remove the need for most of the shell code here (at the cost of the file being harder to parse)