### PR TITLE
:recycle: Clarify pipe usage in shortlines example

### DIFF
--- a/markdown/source_md/input-and-output.md
+++ b/markdown/source_md/input-and-output.md
@@ -788,7 +788,7 @@ so am i
 short
 ```
 
-We pipe the contents of *shortlines.txt* into the output of *shortlinesonly* and as the output, we only get the short lines.
+We pipe the contents of *shortlines.txt* into *shortlinesonly*, and the output contains only the short lines.
 
 This pattern of getting some string from the input, transforming it with a function and then outputting that is so common that there exists a function which makes that even easier, called `interact`{.label .function}.
 `interact` takes a function of type `String -> String` as a parameter and returns an I/O action that will take some input, run that function on it and then print out the function's result.


### PR DESCRIPTION
Fix for https://github.com/learnyouahaskell/learnyouahaskell.github.io/issues/104

Rather than swapping output for input, I _attempted_ to make the sentence more expressive/clear.