### PR TITLE
Fix minor typo

### DIFF
--- a/markdown/source_md/a-fistful-of-monads.md
+++ b/markdown/source_md/a-fistful-of-monads.md
@@ -222,7 +222,7 @@ class Monad m where
 Let's start with the first line.
 It says `class Monad m where`.
 But wait, didn't we say that monads are just beefed up applicative functors?
-Shouldn't there be a class constraint in there along the lines of `class (Applicative m) = > Monad m where` so that a type has to be an applicative functor first before it can be made a monad?
+Shouldn't there be a class constraint in there along the lines of `class (Applicative m) => Monad m where` so that a type has to be an applicative functor first before it can be made a monad?
 Well, there should, but when Haskell was made, it hadn't occurred to people that applicative functors are a good fit for Haskell so they weren't in there.
 But rest assured, every monad is an applicative functor, even if the `Monad` class declaration doesn't say so.
 


### PR DESCRIPTION
fixed typo in typeclass operator from `= >` to `=>` in [chap.12](https://learnyouahaskell.github.io/a-fistful-of-monads.html#the-monad-type-class:~:text=(Applicative%20m)%20%3D%20%3E%20Monad%20m%20where);

<img width="738" height="158" alt="image" src="https://github.com/user-attachments/assets/0c7be9c7-80eb-46df-a6f8-5d190cfac75e" />

to

<img width="772" height="153" alt="image" src="https://github.com/user-attachments/assets/ff112993-f3b9-414b-9867-7d16fd772f85" />
