### PR TITLE
Set the required 'lang' attribute, for all generated HTML files

### DIFF
--- a/markdown/config/template.html
+++ b/markdown/config/template.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN"
    "https://www.w3.org/TR/html4/strict.dtd">
-<html>
+<html lang="en">
 <head>
 <title>$title$ - Learn You a Haskell for Great Good!</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">


### PR DESCRIPTION
The html tag's lang attribute is required. 

This simply sets it to 'en' in the template file to match the other html files.