### PR TITLE
`let` in GHCi

### DIFF
--- a/source_md/higher-order-functions.md
+++ b/source_md/higher-order-functions.md
@@ -130,7 +130,7 @@ From the definition of sections, `(-4)` would result in a function that takes a 
 However, for convenience, `(-4)` means minus four.
 So if you want to make a function that subtracts 4 from the number it gets as a parameter, partially apply the `subtract` function like so: `(subtract 4)`.
 
-What happens if we try to just do `multThree 3 4` in GHCi instead of binding it to a name with a `let` or passing it to another function?
+What happens if we try to just do `multThree 3 4` in GHCi instead of binding it to a name or passing it to another function?
 
 ```{.haskell:hs}
 ghci> multThree 3 4

--- a/source_md/input-and-output.md
+++ b/source_md/input-and-output.md
@@ -220,8 +220,8 @@ Even when we just punch out a number or call a function in GHCi and press return
 Remember `let` bindings?
 If you don't, refresh your memory on them by reading [this section](syntax-in-functions.html#let-it-be).
 They have to be in the form of <code>let *bindings* in *expression*</code>, where <code>*bindings*</code> are names to be given to expressions and <code>*expression*</code> is the expression that is to be evaluated that sees them.
-We also said that in list comprehensions, the `in` part isn't needed.
-Well, you can use them in `do` blocks pretty much like you use them in list comprehensions.
+We also said that in list comprehensions and in GHCi, the `in` part isn't needed.
+Well, you can use them in `do` blocks pretty much the same way.
 Check this out:
 
 ```{.haskell:hs}

--- a/source_md/syntax-in-functions.md
+++ b/source_md/syntax-in-functions.md
@@ -583,9 +583,6 @@ ghci> boot
 Back in the day, using `let` used to be required when binding in GHCi.
 A bit inconvenient!
 These days you can omit the `let` and enjoy exactly the same result.
-But why, you may wonder, require `let` in the first place?
-The answer is that the notation at GHCi's prompt was modeled after a syntactic form called *`do`-notation*.
-You'll get to know this syntax when we get to dealing with `IO`.
 :::
 
 If `let` bindings are so cool, why not use them all the time instead of `where` bindings, you ask?

--- a/source_md/syntax-in-functions.md
+++ b/source_md/syntax-in-functions.md
@@ -577,6 +577,17 @@ ghci> boot
 <interactive>:1:0: Not in scope: `boot'
 ```
 
+::: {.hintbox}
+**Let's not.**
+
+Back in the day, using `let` used to be required when binding in GHCi.
+A bit inconvenient!
+These days you can omit the `let` and enjoy exactly the same result.
+But why, you may wonder, require `let` in the first place?
+The answer is that the notation at GHCi's prompt was modeled after a syntactic form called *`do`-notation*.
+You'll get to know this syntax when we get to dealing with `IO`.
+:::
+
 If `let` bindings are so cool, why not use them all the time instead of `where` bindings, you ask?
 Well, since `let` bindings are expressions and are fairly local in their scope, they can't be used across guards.
 Some people prefer `where` bindings because the names come after the function they're being used in.

--- a/source_md/syntax-in-functions.md
+++ b/source_md/syntax-in-functions.md
@@ -556,6 +556,17 @@ ghci> boot
 <interactive>:1:0: Not in scope: `boot'
 ```
 
+::: {.hintbox}
+**Let's not.**
+
+Back in the day, using `let` used to be required when binding in GHCi.
+A bit inconvenient!
+These days you can omit the `let` and enjoy exactly the same result.
+But why, you may wonder, require `let` in the first place?
+The answer is that the notation at GHCi's prompt was modeled after a syntactic form called *`do`-notation*.
+You'll get to know this syntax when we get to dealing with `IO`.
+:::
+
 If `let` bindings are so cool, why not use them all the time instead of `where` bindings, you ask?
 Well, since `let` bindings are expressions and are fairly local in their scope, they can't be used across guards.
 Some people prefer `where` bindings because the names come after the function they're being used in.

--- a/source_md/syntax-in-functions.md
+++ b/source_md/syntax-in-functions.md
@@ -562,9 +562,6 @@ ghci> boot
 Back in the day, using `let` used to be required when binding in GHCi.
 A bit inconvenient!
 These days you can omit the `let` and enjoy exactly the same result.
-But why, you may wonder, require `let` in the first place?
-The answer is that the notation at GHCi's prompt was modeled after a syntactic form called *`do`-notation*.
-You'll get to know this syntax when we get to dealing with `IO`.
 :::
 
 If `let` bindings are so cool, why not use them all the time instead of `where` bindings, you ask?


### PR DESCRIPTION
This PR's main contribution is a note about `let` not being needed anymore when binding to names in GHCi.

I haven't touched the many `ghci> let` occurrences in the book. Some were already updated (#24), but keeping some or even many of the rest doesn't seem harmful. If it is desired that they are all removed, I'd still like to add a note that both forms exist and are synonymous, so that seeing `let`s in other older resources will be less surprising.